### PR TITLE
fix(unit): ensure invalid format returns format string

### DIFF
--- a/Elements.Quantity.Tests/Core/QuantityHelperTests.cs
+++ b/Elements.Quantity.Tests/Core/QuantityHelperTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Elements.Quantity.Test.Mocks;
+using System.Text.RegularExpressions;
+
+namespace Elements.Quantity.Test.Core;
+
+[TestClass]
+[ExcludeFromCodeCoverage]
+public partial class QuantityHelperTests
+{
+    internal static IEnumerable<object[]> ValueFormatArgs => SharedArgsProvider.ValidFormatArgs
+        .Concat(SharedArgsProvider.InvalidFormatArgs)
+        .Select(argsData => new[] { argsData.formatNum, MockUnitPrefixRegex().Replace(argsData.expectedValue, "m") });
+
+    /// <summary>
+    /// Tests that the <see cref="QuantityHelper.FormatAs"/> method correctly formats a quantity using a valid string
+    /// format and unit.
+    /// </summary>
+    /// <param name="formatNum">The string format to apply to the quantity's numeric value.</param>
+    /// <param name="expectedValue">The expected formatted string result.</param>
+    [TestMethod]
+    [DynamicData(nameof(ValueFormatArgs))]
+    public void QuantityHelperFormatAs_ProvidedStringFormatAndUnitAreValid_FormatsUnitNumberInFormat(string formatNum, string expectedValue)
+    {
+        var unit = Distance.Meter;
+        var quantity = new Distance(unit.Ratio);
+
+        
+        var formattedValue = quantity.FormatAs(unit, formatNum);
+        Assert.AreEqual(expectedValue, formattedValue);
+    }
+
+    /// <summary>
+    /// Tests that the <see cref="QuantityHelper.FormatAs"/> method correctly formats a unit number when
+    /// provided with a valid string format and unit name.
+    /// </summary>
+    /// <remarks>In the future, all valid unit name strings will be collected to test against. For now, only <c>" m"</c>
+    /// is used.</remarks>
+    /// <param name="formatNum">The string format to apply to the quantity's numeric value.</param>
+    /// <param name="expectedValue">The expected formatted string result.</param>
+    [TestMethod]
+    [DynamicData(nameof(ValueFormatArgs))]
+    public void QuantityHelperFormatAs_ProvidedStringFormatAndUnitNameAreValid_FormatsUnitNumberInFormat(string formatNum, string expectedValue)
+    {
+        var unit = Distance.Meter;
+        var quantity = new Distance(unit.Ratio);
+
+        var formattedValue = quantity.FormatAs(" m", formatNum);
+        Assert.AreEqual(expectedValue, formattedValue);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="QuantityHelper.FormatAs"/> method throws a  <see
+    /// cref="UnitNameNotFoundException"/> when an invalid unit name is provided.
+    /// </summary>
+    [TestMethod]
+    public void QuantityHelperFormatAs_ProvidedUnitNameIsInvalid_ThrowsException()
+    {
+        var quantity = new Distance(Distance.Meter.Ratio);
+        Assert.ThrowsExactly<UnitNameNotFoundException>(() => quantity.FormatAs("mockunit", "#"));
+    }
+
+    [GeneratedRegex("u$", RegexOptions.Compiled)]
+    private static partial Regex MockUnitPrefixRegex();
+}

--- a/Elements.Quantity.Tests/Core/UnitTests.cs
+++ b/Elements.Quantity.Tests/Core/UnitTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Elements.Quantity.Test.Mocks;
+using System.Linq;
+
+namespace Elements.Quantity.Test.Core;
+
+[TestClass]
+[ExcludeFromCodeCoverage]
+public class UnitTests
+{
+    internal static IEnumerable<object[]> ValueFormatArgs => SharedArgsProvider.ValidFormatArgs
+        .Concat(SharedArgsProvider.InvalidFormatArgs)
+        .Select(argsData => new [] { argsData.formatNum, argsData.expectedValue });
+
+    /// <summary>
+    /// Tests that the <see cref="Unit{T}.FormatAs(T, string, bool, string)"/> method correctly formats a
+    /// unit's value using the specified string format.
+    /// </summary>
+    /// <param name="formatNum">The string format to apply to the unit's value.</param>
+    /// <param name="expectedValue">The expected formatted value of the unit.</param>
+    [TestMethod]
+    [DynamicData(nameof(ValueFormatArgs))]
+    public void UnitFormatAs_ProvidedStringFormatIsValid_FormatsUnitNumberInFormat(string formatNum, string expectedValue)
+    {
+        var unit = MockProvider.MockUnit;
+        var quantity = new MockQuantity(unit.Ratio);
+
+        var formattedValue = unit.FormatAs(quantity, formatNum);
+        Assert.AreEqual(expectedValue, formattedValue);
+    }
+}

--- a/Elements.Quantity.Tests/DataProvider.cs
+++ b/Elements.Quantity.Tests/DataProvider.cs
@@ -4,16 +4,63 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Elements.Quantity.Test
-{
-    internal static class DataProvider
-    {
-        internal static IEnumerable<double> UnitQuantityPluralNumberValues => new[]
-        {
-            -2.3, -0.8, 0, 0.9, 1.2
-        };
+namespace Elements.Quantity.Test;
 
-        internal static IEnumerable<double> UnitQuantityShortNameNumberValues =>
-            UnitQuantityPluralNumberValues.Union(new[] { 1d });
-    }
+internal static class DataProvider
+{
+    internal static IEnumerable<double> UnitQuantityPluralNumberValues =>
+    [
+        -2.3, -0.8, 0, 0.9, 1.2
+    ];
+
+    internal static IEnumerable<double> UnitQuantityShortNameNumberValues =>
+        UnitQuantityPluralNumberValues.Union([1d]);
+
+    internal static IEnumerable<string> ValidStringFormatsWithEscapedInvalidFormats =>
+        ValidStringFormats.Concat(InvalidStringFormats.Select(format => $"\\{format}"));
+
+    internal static readonly string[] ValidStringFormats =
+    [
+        ".",
+        "#",
+        "#.0",
+        "#.00",
+        "0",
+        "0.0",
+        "0.00",
+        "0.#",
+        "0.##",
+        "0.###",
+        "00.#",
+        "000.#",
+        "C",
+        "E",
+        "F",
+        "G",
+        "N",
+        "P",
+        "R",
+        "My unit number is #",
+        "X is #.0",
+        "My Number is Gone!",
+        "Providing no number format at all\\.",
+        "Just some random text?",
+        "Providing a Format to ToString like this replaces the whole text with this\\."
+    ];
+
+    internal static readonly string[] InvalidStringFormats =
+    [
+        "B",
+        "D",
+        "I",
+        "M",
+        "Q",
+        "S",
+        "X",
+        "Y",
+        "Z",
+        "B2",
+        "D2",
+        "X4"
+    ];
 }

--- a/Elements.Quantity.Tests/MockProvider.cs
+++ b/Elements.Quantity.Tests/MockProvider.cs
@@ -1,0 +1,14 @@
+﻿using Elements.Quantity.Test.Mocks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Elements.Quantity.Test;
+
+internal static class MockProvider
+{
+    internal static readonly Unit<MockQuantity> MockUnit =
+        new (1, null, [" u"], [" units", " unit"]);
+}

--- a/Elements.Quantity.Tests/Mocks/MockQuantity.cs
+++ b/Elements.Quantity.Tests/Mocks/MockQuantity.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Elements.Quantity.Test.Mocks
+{
+    [ExcludeFromCodeCoverage]
+    internal readonly struct MockQuantity : IQuantity<MockQuantity>
+    {
+        public readonly double BaseValue;
+        double IQuantity.BaseValue => BaseValue;
+
+        public Unit<MockQuantity> DefaultUnit => throw new NotImplementedException();
+
+        public MockQuantity(double baseValue = 0) : this() { BaseValue = baseValue; }
+        public bool Equals(MockQuantity other) { return BaseValue == other.BaseValue; }
+        public int CompareTo(MockQuantity other) { return BaseValue.CompareTo(other.BaseValue); }
+
+        public MockQuantity New(double baseValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public MockQuantity Add(MockQuantity q)
+        {
+            throw new NotImplementedException();
+        }
+
+        public MockQuantity Subtract(MockQuantity q)
+        {
+            throw new NotImplementedException();
+        }
+
+        public MockQuantity Multiply(double n)
+        {
+            throw new NotImplementedException();
+        }
+
+        public MockQuantity Divide(double n)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Ratio Divide(MockQuantity q)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string[] GetShortBaseNames() => ["u"];
+
+        public string[] GetLongBaseNames() => ["units", "unit"];
+
+        public override bool Equals(object? obj)
+        {
+            return obj is MockQuantity quantity && Equals(quantity);
+        }
+
+        public override int GetHashCode()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Elements.Quantity.Tests/SharedArgsProvider.cs
+++ b/Elements.Quantity.Tests/SharedArgsProvider.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Elements.Quantity.Test;
+
+using FormatArgData = (string formatNum, string expectedValue);
+
+public static class SharedArgsProvider
+{
+    internal static string CurrentCurrencySymbol => NumberFormatInfo.CurrentInfo.CurrencySymbol;
+
+    internal static string CurrentNumberDecimalSeparator => NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
+
+    internal static IEnumerable<FormatArgData> ValidFormatArgs =>
+        DataProvider.ValidStringFormatsWithEscapedInvalidFormats.Select(format => (format, $"{1.0d.ToString(format)} u"));
+
+    internal static IEnumerable<FormatArgData> InvalidFormatArgs =>
+        DataProvider.InvalidStringFormats.Select(format => (format, $"{format} u"));
+}

--- a/Elements.Quantity/Core/Internal/NumberExtension.cs
+++ b/Elements.Quantity/Core/Internal/NumberExtension.cs
@@ -7,5 +7,19 @@ namespace Elements.Quantity.Core.Internal
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsSingular(this double number) => Math.Abs(number - 1) < 1e-8;
+
+        public static string Format(this double number, string? format)
+        {
+            try
+            {
+                return number.ToString(format);
+            }
+            catch (FormatException)
+            {
+                // The format can never be null since this exception is thrown with
+                // a provided format value.
+                return format!;
+            }
+        }
     }
 }

--- a/Elements.Quantity/Core/QuantityHelper.cs
+++ b/Elements.Quantity/Core/QuantityHelper.cs
@@ -40,7 +40,7 @@ namespace Elements.Quantity
             bool longName = false) where T : unmanaged, IQuantity<T>
         {
             // find the unit
-            var unit = GetUnitByName<T>(unitName);
+            var unit = GetUnitByName<T>(unitName.Trim());
 
             if (unit == null)
                 throw new UnitNameNotFoundException(unitName);

--- a/Elements.Quantity/Core/Unit.cs
+++ b/Elements.Quantity/Core/Unit.cs
@@ -64,7 +64,7 @@ namespace Elements.Quantity
             }
         }
 
-        public Unit(double baseRatio, ICollection<UnitGroup> unitGroups,
+        public Unit(double baseRatio, ICollection<UnitGroup>? unitGroups,
             string[] shortNames,
             string[] longNames)
         {
@@ -245,7 +245,7 @@ namespace Elements.Quantity
             string? overrideName = null)
         {
             var quantityValue = ConvertTo(q);
-            var numberText = quantityValue.ToString(formatNum);
+            var numberText = quantityValue.Format(formatNum);
 
             var unitName = overrideName != null ? overrideName : GetDefaultUnitNameByValue(quantityValue, useLongName);
 


### PR DESCRIPTION
> ~~If approved, this PR should be merged after #11 since this branch was made off #11. The key commits in this PR are the ones made after 2024.~~

This PR addresses `FormatException` that is thrown when a singular string character is given as a formatter. Since `FormatAs` returns the formatted `double` with the unit short or long name, this particular exception is caught and returns the provided format (i.e., it is as if the invalid format is escaped).

<img width="613" height="125" alt="image" src="https://github.com/user-attachments/assets/178c09d4-0d07-44be-98df-1f8c824dd5b6" />

This should also take care of https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/5507 once Resonite has the updated library.

Fixes #25