### PR TITLE
feat: add formatter option to help with locale

### DIFF
--- a/Elements.Quantity.Tests/Mocks/MockQuantity.cs
+++ b/Elements.Quantity.Tests/Mocks/MockQuantity.cs
@@ -15,6 +15,8 @@ namespace Elements.Quantity.Test.Mocks
 
         public Unit<MockQuantity> DefaultUnit => throw new NotImplementedException();
 
+        public string QuantityFamily => "Mock";
+
         public MockQuantity(double baseValue = 0) : this() { BaseValue = baseValue; }
         public bool Equals(MockQuantity other) { return BaseValue == other.BaseValue; }
         public int CompareTo(MockQuantity other) { return BaseValue.CompareTo(other.BaseValue); }

--- a/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
@@ -14,7 +14,7 @@ public class AccelerationTests
     {
         get => new AccelerationTestData[]
         {
-            new (Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second per second", "{0} meters per second per second")
+            new (Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second squared", "{0} meters per second squared")
         };
     }
 

--- a/Elements.Quantity/Core/Internal/StringExtension.cs
+++ b/Elements.Quantity/Core/Internal/StringExtension.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Elements.Quantity.Core.Internal
+{
+    internal static class StringExtension
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string ToPascalCase(this string str) =>
+            !string.IsNullOrEmpty(str) && !char.IsUpper(str[0])
+                ? $"{char.ToUpper(str[0])}{str.Substring(1)}"
+                : str;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Join(this IEnumerable<string> strings, string separator = "") => string.Join(separator, strings);
+    }
+}

--- a/Elements.Quantity/Core/QuantityHelper.cs
+++ b/Elements.Quantity/Core/QuantityHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Globalization;
 using System.Reflection;
+using System.Linq;
 
 namespace Elements.Quantity
 {
@@ -161,6 +162,12 @@ namespace Elements.Quantity
         {
             return unitCache[typeof(T)];
         }
+
+        public static IEnumerable<IUnit> GetAllUnits() =>
+            unitCache.Values.SelectMany(u => u);
+
+        public static IEnumerable<string> GetUnitKeys() =>
+            GetAllUnits().Select(u => u.UnitKey).OrderBy(k => k);
 
         public static Unit<T> SelectBestUnit<T>(this T q, List<UnitGroup> groups)
             where T : unmanaged, IQuantity<T>

--- a/Elements.Quantity/Core/QuantityInterfaces.cs
+++ b/Elements.Quantity/Core/QuantityInterfaces.cs
@@ -28,6 +28,15 @@ namespace Elements.Quantity
         Ratio Divide(T q);
 
         Unit<T> DefaultUnit { get; }
+
+        /// <summary>
+        /// The quantity family that this quantity type belongs to.
+        /// </summary>
+        /// <remarks>
+        /// This is used to generate the value for <see cref="Unit{T}.UnitKey"/>. For quantity
+        /// types that fall under the 'Basic' family, an empty string should always be returned.
+        /// </remarks>
+        string QuantityFamily { get; }
     }
 
     public interface IQuantitySI

--- a/Elements.Quantity/Core/UnitNonLinear.cs
+++ b/Elements.Quantity/Core/UnitNonLinear.cs
@@ -15,7 +15,8 @@ namespace Elements.Quantity
             Func<double, double> convertFromFunc,
             ICollection<UnitGroup> unitGroups,
             string[] shortNames,
-            string[] longNames) : base(0f, unitGroups, shortNames, longNames)
+            string[] longNames,
+            string? unitNameKeyOverride = null) : base(0f, unitGroups, shortNames, longNames, unitNameKeyOverride)
         {
             this.convertToFunc = convertToFunc;
             this.convertFromFunc = convertFromFunc;

--- a/Elements.Quantity/Quantities/Basic/Acceleration.cs
+++ b/Elements.Quantity/Quantities/Basic/Acceleration.cs
@@ -43,7 +43,7 @@ namespace Elements.Quantity
 
         public static readonly Unit<Acceleration> MetersPerSecondPerSecond = new Unit<Acceleration>(1,
             new UnitGroup[] { UnitGroup.Common, UnitGroup.Metric },
-            new string[] { " m/s^2", " m/s/s" }, new string[] { " meters per second per second", " meter per second per second", " meters per second squared", " meter per second squared" });
+            new string[] { " m/s^2", " m/s/s" }, new string[] { " meters per second squared", " meter per second squared", " meters per second per second", " meter per second per second" });
 
         #endregion
 

--- a/Elements.Quantity/Quantities/Basic/Acceleration.cs
+++ b/Elements.Quantity/Quantities/Basic/Acceleration.cs
@@ -39,6 +39,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Acceleration> DefaultUnit { get { return MetersPerSecondPerSecond; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
 
         public static readonly Unit<Acceleration> MetersPerSecondPerSecond = new Unit<Acceleration>(1,

--- a/Elements.Quantity/Quantities/Basic/Angle.cs
+++ b/Elements.Quantity/Quantities/Basic/Angle.cs
@@ -70,6 +70,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Angle> DefaultUnit { get { return Radian; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 

--- a/Elements.Quantity/Quantities/Basic/Density.cs
+++ b/Elements.Quantity/Quantities/Basic/Density.cs
@@ -28,6 +28,9 @@ namespace Elements.Quantity
 
         public Unit<Density> DefaultUnit { get { return KilogramPerCubicMeter; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Density> KilogramPerCubicMeter = new Unit<Density>(1,
             new UnitGroup[] { UnitGroup.Common },
             new string[] { " kg/m³", " kg/m^3" }, new string[] { " kilograms per cubic meter", " kilogram per cubic meter" });

--- a/Elements.Quantity/Quantities/Basic/Distance.cs
+++ b/Elements.Quantity/Quantities/Basic/Distance.cs
@@ -66,6 +66,9 @@ namespace Elements.Quantity
 
         public Unit<Distance> DefaultUnit { get { return Meter; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Distance> Meter = new UnitSI<Distance>(0, "", "");
 
         // Scientific

--- a/Elements.Quantity/Quantities/Basic/Luminance.cs
+++ b/Elements.Quantity/Quantities/Basic/Luminance.cs
@@ -28,6 +28,9 @@ namespace Elements.Quantity
 
         public Unit<Luminance> DefaultUnit { get { return CandelaPerSquareMeter; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Luminance> CandelaPerSquareMeter = new Unit<Luminance>(1,
             new UnitGroup[] { UnitGroup.Common },
             new string[] { " cd/m²", " cd/m^2" }, new string[] { " candelas per square meter", " candela per square meter" });

--- a/Elements.Quantity/Quantities/Basic/Mass.cs
+++ b/Elements.Quantity/Quantities/Basic/Mass.cs
@@ -71,6 +71,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Mass> DefaultUnit { get { return SI<Mass>.Kilo; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 

--- a/Elements.Quantity/Quantities/Basic/Pressure.cs
+++ b/Elements.Quantity/Quantities/Basic/Pressure.cs
@@ -77,6 +77,9 @@ namespace Elements.Quantity
 
         public Unit<Pressure> DefaultUnit { get { return Pascal; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Pressure> Pascal = new UnitSI<Pressure>(0, "", "");
         public static readonly Unit<Pressure> Bar = new Unit<Pressure>(1e5,
             new UnitGroup[] { UnitGroup.Common },

--- a/Elements.Quantity/Quantities/Basic/Ratio.cs
+++ b/Elements.Quantity/Quantities/Basic/Ratio.cs
@@ -39,6 +39,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Ratio> DefaultUnit { get { return RatioValue; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
 
         public static readonly Unit<Ratio> RatioValue = new Unit<Ratio>(1,

--- a/Elements.Quantity/Quantities/Basic/Temperature.cs
+++ b/Elements.Quantity/Quantities/Basic/Temperature.cs
@@ -39,6 +39,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Temperature> DefaultUnit { get { return Kelvin; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 
@@ -49,12 +52,14 @@ namespace Elements.Quantity
         public static readonly Unit<Temperature> Celsius = new UnitNonLinear<Temperature>(
             (K)=>(K-273.15), (C)=>(C+273.15),
             new UnitGroup[] { UnitGroup.Common },
-            new string[] { " °C" }, new string[] { " degrees Celsius", " degree Celsius", " Celsius" });
+            new string[] { " °C" }, new string[] { " degrees Celsius", " degree Celsius", " Celsius" },
+            "Celsius");
 
         public static readonly Unit<Temperature> Fahrenheit = new UnitNonLinear<Temperature>(
             (K) => (K * (9.0 / 5.0) - 459.67), (F) => ((F + 459.67)*(5.0 / 9.0)),
             new UnitGroup[] { UnitGroup.Common },
-            new string[] { " °F" }, new string[] { " degrees Fahrenheit", " degree Fahrenheit", " Fahrenheit" });
+            new string[] { " °F" }, new string[] { " degrees Fahrenheit", " degree Fahrenheit", " Fahrenheit" },
+            "Fahrenheit");
 
         #endregion
 

--- a/Elements.Quantity/Quantities/Basic/Time.cs
+++ b/Elements.Quantity/Quantities/Basic/Time.cs
@@ -39,6 +39,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Time> DefaultUnit { get { return Second; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Time> Millisecond = new Unit<Time>(1.0 / 1000.0,
             new UnitGroup[] { UnitGroup.Common },
             new string[] { " ms" }, new string[] { " milliseconds", " millisecond" });

--- a/Elements.Quantity/Quantities/Basic/Torque.cs
+++ b/Elements.Quantity/Quantities/Basic/Torque.cs
@@ -28,6 +28,9 @@ namespace Elements.Quantity
 
         public Unit<Torque> DefaultUnit { get { return NewtonMeter; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Torque> NewtonMeter = new Unit<Torque>(1,
             new UnitGroup[] { UnitGroup.Common },
             new string[] { " N m", " N·m" }, new string[] { " newton meters", " newton meter", " newton metres", " newton metre" });

--- a/Elements.Quantity/Quantities/Basic/Velocity.cs
+++ b/Elements.Quantity/Quantities/Basic/Velocity.cs
@@ -39,6 +39,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Velocity> DefaultUnit { get { return MetersPerSecond; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
 
         public static readonly Unit<Velocity> MetersPerSecond = new Unit<Velocity>(1,

--- a/Elements.Quantity/Quantities/Electronic/Current.cs
+++ b/Elements.Quantity/Quantities/Electronic/Current.cs
@@ -86,6 +86,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Current> DefaultUnit { get { return Ampere; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => "Electronic";
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 

--- a/Elements.Quantity/Quantities/Electronic/Resistance.cs
+++ b/Elements.Quantity/Quantities/Electronic/Resistance.cs
@@ -86,6 +86,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Resistance> DefaultUnit { get { return Ohm; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => "Electronic";
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 

--- a/Elements.Quantity/Quantities/Electronic/Voltage.cs
+++ b/Elements.Quantity/Quantities/Electronic/Voltage.cs
@@ -86,6 +86,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Voltage> DefaultUnit { get { return Volt; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => "Electronic";
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 


### PR DESCRIPTION
This PR aims to add open-ended formatter options to help define custom formatting behavior for unit types. One use case for this feature is to provide a different name for the unit based on the current locale.

This PR will be considered complete once the following tasks are done:

- [x] Add string key generation for units. (#46)
- [ ] Add formatter feature to `Quantity` (i.e., single values).
- [ ] Add formatter feature to `CompoundFormatInfo` (i.e., multiple values such as hours, minutes, and seconds).

Resolves #12