### PR TITLE
feat: upgrade library to dotnet 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,13 @@ on:
 
 jobs:
   build:
-    # Windows Server 2022 contains .NET 9
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v5
-    - name: Setup .NET 9
-      uses: actions/setup-dotnet@v4
+    - uses: actions/checkout@v6
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,18 +6,17 @@ on:
     types: [published]
 jobs:
   publish:
-    # Windows Server 2022 contains .NET 9
-    runs-on: windows-2022
+    runs-on: windows-latest
     env:
       VERSION: ${{ github.event.release.tag_name }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Get version
       run: echo "Building with ${{ env.VERSION }}"
-    - name: Setup .NET 9
-      uses: actions/setup-dotnet@v4
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test Library
+﻿name: Test Library
 
 on:
   workflow_dispatch:
@@ -24,19 +24,19 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v5
-      - name: Setup .NET 9
-        uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v6
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
       - name: Install Dependencies
         run: dotnet restore
       - name: Run Test
         run: dotnet test --configuration Release --no-restore --logger "trx;LogFileName=test-results.trx" || true
       - name: Generate Test Report
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         if: success() || failure()
         with:
           name: Elements.Quantity.Test

--- a/Elements.Quantity.Tests/Elements.Quantity.Test.csproj
+++ b/Elements.Quantity.Tests/Elements.Quantity.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
@@ -10,7 +10,7 @@
     <IsCodedUITest>False</IsCodedUITest>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="3.10.4" />
+    <PackageReference Include="MSTest" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elements.Quantity\Elements.Quantity.csproj" />

--- a/Elements.Quantity.sln
+++ b/Elements.Quantity.sln
@@ -1,11 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.7.34031.279
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elements.Quantity", "Elements.Quantity\Elements.Quantity.csproj", "{7DA9B41E-A0F0-4392-8672-966642C94884}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elements.Quantity.Test", "Elements.Quantity.Tests\Elements.Quantity.Test.csproj", "{40DBC8C3-EF68-47E0-AA3C-83692A649E60}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github_workflows", ".github_workflows", "{8957ABB7-35FA-46B3-AFBB-55AAD5F8361B}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
+		.github\workflows\release.yml = .github\workflows\release.yml
+		.github\workflows\test.yml = .github\workflows\test.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Elements.Quantity/Elements.Quantity.csproj
+++ b/Elements.Quantity/Elements.Quantity.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Company>Yellow Dog Man Studios</Company>


### PR DESCRIPTION
Since .Net 10 is all the rage these days, this library should be upgraded to that version as well. This PR upgrades the library to .Net 10.

Do note the following with the current library:

* .Net 9 support will end in November 2026.
* Since the library in releases and NuGet is two years old (see #33), that library targets .NET Framework 4.6.2. That version's end of support is in January 2027.

~~I am bending my word a bit regarding my future contributions to this repository. However, I will be returning to my word after this PR; I will not contribute to this library anymore. The concerns noted in #33 are just a factor of why I am no longer contributing to the library.~~

Edit: After talking to @Frooxius, I will give this repository a second chance. My concerns noted in #33 are still valid.