### PR TITLE
test(distance): add format test for nautical mile and fathom

### DIFF
--- a/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
@@ -26,6 +26,7 @@ public class DistanceTests
             new (Distance.SolarRadius, "{0} R☉", "1 Solar radius", "{0} Solar radii"),
             new (Distance.Thou, "{0} th", "1 thou", "{0} thous"),
             new (Distance.Yard, "{0} yd", "1 yard", "{0} yards"),
+            new (Distance.NauticalMile, "{0} NM", "1 nautical mile", "{0} nautical miles"),
             new (SI<Distance>.Kilo, "{0} km", "1 kilometer", "{0} kilometers"),
             new (SI<Distance>.Centi, "{0} cm", "1 centimeter", "{0} centimeters"),
             new (SI<Distance>.Milli, "{0} mm", "1 millimeter", "{0} millimeters"),

--- a/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
@@ -27,6 +27,7 @@ public class DistanceTests
             new (Distance.Thou, "{0} th", "1 thou", "{0} thous"),
             new (Distance.Yard, "{0} yd", "1 yard", "{0} yards"),
             new (Distance.NauticalMile, "{0} NM", "1 nautical mile", "{0} nautical miles"),
+            new (Distance.Fathom, "{0} ftm", "1 fathom", "{0} fathoms"),
             new (SI<Distance>.Kilo, "{0} km", "1 kilometer", "{0} kilometers"),
             new (SI<Distance>.Centi, "{0} cm", "1 centimeter", "{0} centimeters"),
             new (SI<Distance>.Milli, "{0} mm", "1 millimeter", "{0} millimeters"),


### PR DESCRIPTION
This PR adds the missing formatting tests for nautical mile and fathom for the distance quantity type.

Relates to #37 