### PR TITLE
fix(density): add correct names and missing singular names 

### DIFF
--- a/Elements.Quantity.Tests/Quantities/Basic/DensityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DensityTests.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Elements.Quantity.Test.Quantities.Basic;
+
+using DensityTestData = (Unit<Density> unit, string shortName, string longNameSingle, string longNamePlural);
+
+[TestClass]
+public class DensityTests
+{
+    /// <summary>
+    /// An array of test data tuples representing different density units and their display formats. Each
+    /// element in the array contains information about a density unit, the short name, the singular
+    /// long name, and plural long name.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static DensityTestData[] DensityTestDataTuples
+    {
+        get =>
+        [
+            new (Density.KilogramPerCubicMeter, "{0} kg/m³", "1 kilogram per cubic meter", "{0} kilograms per cubic meter"),
+            new (Density.GramPerCubicCentimeter, "{0} g/cm³", "1 gram per cubic centimeter", "{0} grams per cubic centimeter"),
+            new (Density.PoundPerCubicFoot, "{0} lb/ft³", "1 pound per cubic foot", "{0} pounds per cubic foot")
+        ];
+    }
+
+    /// <summary>
+    /// A collection of test data containing the density unit, the numeric value, and the expected
+    /// formatted short name.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<object[]> DensityShortNameArgs
+    {
+        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
+            DensityTestDataTuples.Select(densityUnitArgs => new object[] {
+                densityUnitArgs.unit, numValue, string.Format(densityUnitArgs.shortName, numValue)
+            }).ToArray()
+        );
+    }
+
+    /// <summary>
+    /// A collection of test data containing the density unit and the expected formatted long
+    /// name for singluar values.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<object[]> DensityLongNameSingularFormArgs
+    {
+        get => DensityTestDataTuples.Select(densityUnitArgs => new object[] {
+            densityUnitArgs.unit, densityUnitArgs.longNameSingle
+        });
+    }
+
+    /// <summary>
+    /// A collection of test data containing the density unit, the numeric value, and the expected
+    /// formatted long name for plural values.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<object[]> DensityLongNamePluralFormArgs
+    {
+        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
+            DensityTestDataTuples.Select(densityUnitArgs => new object[] {
+                densityUnitArgs.unit, numValue, string.Format(densityUnitArgs.longNamePlural, numValue)
+            }).ToArray()
+        );
+    }
+
+    /// <summary>
+    /// Verifies that formatting a Density quantity using the specified unit and the default short name produces the
+    /// expected string representation.
+    /// </summary>
+    /// <remarks>
+    /// This test ensures that the FormatAs method correctly applies the unit's default short name
+    /// when formatting a density value. It uses dynamic data to validate multiple unit and string
+    /// combinations.
+    /// </remarks>
+    /// <param name="densityUnit">The density unit to use when formatting the value.</param>
+    /// <param name="densityValue">The numeric value to be formatted.</param>
+    /// <param name="expectedStr">The expected string result when formatting the density value with the specified unit's default short name.</param>
+    [TestMethod]
+    [DynamicData(nameof(DensityShortNameArgs))]
+    public void DensityUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Density> densityUnit, double densityValue, string expectedStr)
+    {
+        var density = new Density(densityValue * densityUnit.Ratio);
+        var resultStr = density.FormatAs(densityUnit, formatNum: "0.#");
+
+        Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that formatting a density value using the specified unit with the long name option produces
+    /// the expected singular long name string for singular values.
+    /// </summary>
+    /// <remarks>
+    /// This test ensures that the FormatAs method correctly applies the singular form of the
+    /// unit's long name when formatting density values.
+    /// </remarks>
+    /// <param name="densityUnit">The density unit to use when formatting the value.</param>
+    /// <param name="expectedStr">The expected string result when formatting the density value with the long name option.</param>
+    [TestMethod]
+    [DynamicData(nameof(DensityLongNameSingularFormArgs))]
+    public void DensityUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Density> densityUnit, string expectedStr)
+    {
+        var density = new Density(densityUnit.Ratio);
+        var resultStr = density.FormatAs(densityUnit, longName: true, formatNum: "0.#");
+
+        Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that formatting a density value using the specified unit with the long name option produces
+    /// the expected plural long name string for plural values.
+    /// </summary>
+    /// <remarks>
+    /// This test ensures that the FormatAs method correctly applies the  plural form of the
+    /// unit's long name when formatting density values.
+    /// </remarks>
+    /// <param name="densityUnit">The density unit to use when formatting the value.</param>
+    /// <param name="densityValue">The numeric value to be formatted.</param>
+    /// <param name="expectedStr">The expected string result when formatting the density value with the long name option.</param>
+    [TestMethod]
+    [DynamicData(nameof(DensityLongNamePluralFormArgs))]
+    public void DensityUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Density> densityUnit, double densityValue, string expectedStr)
+    {
+        var density = new Density(densityValue * densityUnit.Ratio);
+        var resultStr = density.FormatAs(densityUnit, longName: true, formatNum: "0.#");
+
+        Assert.AreEqual(expectedStr, resultStr);
+    }
+}

--- a/Elements.Quantity/Quantities/Basic/Density.cs
+++ b/Elements.Quantity/Quantities/Basic/Density.cs
@@ -30,15 +30,15 @@ namespace Elements.Quantity
 
         public static readonly Unit<Density> KilogramPerCubicMeter = new Unit<Density>(1,
             new UnitGroup[] { UnitGroup.Common },
-            new string[] { " kg/m³", " kg/m^3" }, new string[] { "kilograms per cubic meter", "kilogram per cubic meter" });
+            new string[] { " kg/m³", " kg/m^3" }, new string[] { " kilograms per cubic meter", " kilogram per cubic meter" });
 
         public static readonly Unit<Density> GramPerCubicCentimeter = new Unit<Density>(1000,
             new UnitGroup[] { UnitGroup.Common },
-            new string[] { " g/cm³", " g/cm^3" }, new string[] { "grams per cubic centimeter", "gram per cubic centimeter" });
+            new string[] { " g/cm³", " g/cm^3" }, new string[] { " grams per cubic centimeter", " gram per cubic centimeter" });
 
         public static readonly Unit<Density> PoundPerCubicFoot = new Unit<Density>(16.0185,
             new UnitGroup[] { UnitGroup.Imperial },
-            new string[] { " lb/ft³", " lb/ft^3" }, new string[] { "pounds per cubic foot", "pound per cubic foot" });
+            new string[] { " lb/ft³", " lb/ft^3" }, new string[] { " pounds per cubic foot", " pound per cubic foot" });
 
         #endregion
 

--- a/Elements.Quantity/Quantities/Basic/Density.cs
+++ b/Elements.Quantity/Quantities/Basic/Density.cs
@@ -30,15 +30,15 @@ namespace Elements.Quantity
 
         public static readonly Unit<Density> KilogramPerCubicMeter = new Unit<Density>(1,
             new UnitGroup[] { UnitGroup.Common },
-            new string[] { " kg/m³" }, new string[] { "kilograms per cubic meter", "kilogram per cubic meter" });
+            new string[] { " kg/m³", " kg/m^3" }, new string[] { "kilograms per cubic meter", "kilogram per cubic meter" });
 
         public static readonly Unit<Density> GramPerCubicCentimeter = new Unit<Density>(1000,
             new UnitGroup[] { UnitGroup.Common },
-            new string[] { " g/cm³" }, new string[] { "grams per cubic centimeter", "gram per cubic centimeter" });
+            new string[] { " g/cm³", " g/cm^3" }, new string[] { "grams per cubic centimeter", "gram per cubic centimeter" });
 
         public static readonly Unit<Density> PoundPerCubicFoot = new Unit<Density>(16.0185,
             new UnitGroup[] { UnitGroup.Imperial },
-            new string[] { " lb/ft³" }, new string[] { "pounds per cubic foot", "pound per cubic foot" });
+            new string[] { " lb/ft³", " lb/ft^3" }, new string[] { "pounds per cubic foot", "pound per cubic foot" });
 
         #endregion
 

--- a/Elements.Quantity/Quantities/Basic/Density.cs
+++ b/Elements.Quantity/Quantities/Basic/Density.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Elements.Quantity
 {
@@ -30,15 +30,15 @@ namespace Elements.Quantity
 
         public static readonly Unit<Density> KilogramPerCubicMeter = new Unit<Density>(1,
             new UnitGroup[] { UnitGroup.Common },
-            new string[] { " kg/m³" }, new string[] { "kilograms per cubic meter" });
+            new string[] { " kg/m³" }, new string[] { "kilograms per cubic meter", "kilogram per cubic meter" });
 
         public static readonly Unit<Density> GramPerCubicCentimeter = new Unit<Density>(1000,
             new UnitGroup[] { UnitGroup.Common },
-            new string[] { " g/cm³" }, new string[] { "grams per cubic centimeter" });
+            new string[] { " g/cm³" }, new string[] { "grams per cubic centimeter", "gram per cubic centimeter" });
 
         public static readonly Unit<Density> PoundPerCubicFoot = new Unit<Density>(16.0185,
             new UnitGroup[] { UnitGroup.Imperial },
-            new string[] { " lb/ft³" }, new string[] { "pounds per cubic foot" });
+            new string[] { " lb/ft³" }, new string[] { "pounds per cubic foot", "pound per cubic foot" });
 
         #endregion
 

--- a/Elements.Quantity/Quantities/Basic/Density.cs
+++ b/Elements.Quantity/Quantities/Basic/Density.cs
@@ -19,8 +19,8 @@ namespace Elements.Quantity
 
         #region QUANTITY NAME DEFINITIONS
 
-        public string[] GetShortBaseNames() { return new string[] { "kg/m³" }; }
-        public string[] GetLongBaseNames() { return new string[] { "kilograms per cubic meter", "kilogram per cubic meter" }; }
+        public string[] GetShortBaseNames() { return new string[] { "" }; }
+        public string[] GetLongBaseNames() { return new string[] { "" }; }
 
         #endregion
 


### PR DESCRIPTION
This PR aims to fix the short and long names found in the density quantity type.  Here is what was performed:

* Add missing singular forms for all types
* Add missing space for existing long names
* Add non-superscript forms
* Remove default base names since that is only applicable for `IQuantitySI<T>`.

Missing unit tests have also been added to verify the formatting process.

Relates to #37 
Relates to #40 