### PR TITLE
feat(pressure): add mbar and psi units

### DIFF
--- a/Elements.Quantity.Tests/Quantities/Basic/PressureTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/PressureTests.cs
@@ -25,6 +25,8 @@ public class PressureTests
             new (Pressure.Bar, "{0} bar", "1 bar", "{0} bars"),
             new (Pressure.Atmosphere, "{0} atm", "1 standard atmosphere", "{0} standard atmospheres"),
             new (Pressure.Torr, "{0} Torr", "1 torr", "{0} torrs"),
+            new (Pressure.Millibar, "{0} mbar", "1 millibar", "{0} millibars"),
+            new (Pressure.PoundPerSquareInch, "{0} psi", "1 pound per square inch", "{0} pounds per square inch"),
             new (SI<Pressure>.Quecto, "{0} qPa", "1 quectopascal", "{0} quectopascals"),
             new (SI<Pressure>.Ronto, "{0} rPa", "1 rontopascal", "{0} rontopascals"),
             new (SI<Pressure>.Yocto, "{0} yPa", "1 yoctopascal", "{0} yoctopascals"),

--- a/Elements.Quantity/Quantities/Basic/Pressure.cs
+++ b/Elements.Quantity/Quantities/Basic/Pressure.cs
@@ -87,6 +87,12 @@ namespace Elements.Quantity
         public static readonly Unit<Pressure> Torr = new Unit<Pressure>(1.01325e5 / 760,
             new UnitGroup[] { UnitGroup.Common },
             new string[] { " Torr" }, new string[] { " torrs", " torr" });
+        public static readonly Unit<Pressure> Millibar = new Unit<Pressure>(100,
+            new UnitGroup[] { UnitGroup.Common },
+            new string[] { " mbar" }, new string[] { " millibars", " millibar" });
+        public static readonly Unit<Pressure> PoundPerSquareInch = new Unit<Pressure>(1.450377e-4,
+            new UnitGroup[] { UnitGroup.Common },
+            new string[] { " psi", " lbf/in²", " lbf/in^2" }, new string[] { " pounds per square inch", " pound per square inch", "pound-forces per square inch", "pound-force per square inch" });
 
         #endregion
 

--- a/Elements.Quantity/Quantities/Basic/Pressure.cs
+++ b/Elements.Quantity/Quantities/Basic/Pressure.cs
@@ -53,7 +53,7 @@ namespace Elements.Quantity
             };
         }
 
-        public IUnit[] GetExcludedSIUnits()
+        public IUnit[] GetExludedSIUnits()
         {
             return new IUnit[] {
                 SI<Pressure>.Quecto,
@@ -127,17 +127,5 @@ namespace Elements.Quantity
         /* *********************************************** */
 
         public override string ToString() => this.FormatAuto();
-
-        public IUnit[] GetExludedSIUnits()
-        {
-            // TODO: adjust?
-            // The usual exclusions.
-            return new IUnit[] {
-                SI<Angle>.Centi,
-                SI<Angle>.Deca,
-                SI<Angle>.Deci,
-                SI<Angle>.Hecto
-            };
-        }
     }
 }


### PR DESCRIPTION
This PR adds `psi` and `mbar` units to the pressure quantity type as requested in https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/4315.

I wanted to treat `bar` as a `UnitSI<Pressure>` due to the fact that `bar` can follow SI prefixes. However, due to the coupling of the `DefaultUnit` property and the generation of `SI<>` in `QuantityHelper`, it does not play nicely with formatting. For example, the following would be produced:

```
20 barPa
```

This would require a slight overhaul on how `SI<>` is generated in `QuantityHelper` in order for other non-default unit types to utilize SI prefixes. To avoid tampering with `QuantityHelper` to add this additional logic, I added the `Millibar` property for now since `mbar` was specifically mentioned. This property can always refer to the SI form of bar when this logic is implemented in the future.

The PR also addresses "duplicated" excluded SI units that were introduced during the merge. This is due to the `interface` requiring the method `GetExludedSIUnits` (without the "c") while the merged one was called `GetExcludedSIUnits` (the correct spelling of "excluded").

Unit tests were updated to incorporate these new units.

Relates to #33 