### PR TITLE
feat: add unique key per unit

### DIFF
--- a/Elements.Quantity.Tests/Core/QuantityHelperTests.cs
+++ b/Elements.Quantity.Tests/Core/QuantityHelperTests.cs
@@ -66,6 +66,16 @@ public partial class QuantityHelperTests
         Assert.ThrowsExactly<UnitNameNotFoundException>(() => quantity.FormatAs("mockunit", "#"));
     }
 
+    /// <summary>
+    /// Verifies that all quantity units have unique unit keys.
+    /// </summary>
+    [TestMethod]
+    public void GetAllUnitKeys_UniqueUnits_ReturnsUniqueUnitKeys()
+    {
+        var unitKeys = QuantityHelper.GetUnitKeys();
+        CollectionAssert.AllItemsAreUnique(unitKeys.ToArray());
+    }
+
     [GeneratedRegex("u$", RegexOptions.Compiled)]
     private static partial Regex MockUnitPrefixRegex();
 }

--- a/Elements.Quantity.Tests/Mocks/MockQuantity.cs
+++ b/Elements.Quantity.Tests/Mocks/MockQuantity.cs
@@ -15,6 +15,8 @@ namespace Elements.Quantity.Test.Mocks
 
         public Unit<MockQuantity> DefaultUnit => throw new NotImplementedException();
 
+        public string QuantityFamily => "Mock";
+
         public MockQuantity(double baseValue = 0) : this() { BaseValue = baseValue; }
         public bool Equals(MockQuantity other) { return BaseValue == other.BaseValue; }
         public int CompareTo(MockQuantity other) { return BaseValue.CompareTo(other.BaseValue); }

--- a/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
@@ -14,7 +14,7 @@ public class AccelerationTests
     {
         get => new AccelerationTestData[]
         {
-            new (Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second per second", "{0} meters per second per second")
+            new (Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second squared", "{0} meters per second squared")
         };
     }
 

--- a/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
@@ -1,22 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using AccelerationTestData = (Unit<Acceleration> unit, string shortName, string longNameSingle, string longNamePlural);
+using AccelerationTestData = QuantityTestData<Acceleration>;
+using AccelerationUnitKeyTestData = (Unit<Acceleration> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class AccelerationTests
 {
-    internal static AccelerationTestData[] AccelerationTestDataTuples
-    {
-        get => new AccelerationTestData[]
-        {
-            new (Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second squared", "{0} meters per second squared")
-        };
-    }
+    /// <summary>
+    /// An array of test data tuples representing different acceleration units and their display formats. Each
+    /// element in the array contains information about a acceleration unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static AccelerationTestData[] AccelerationTestDataTuples =>
+    [
+        new (Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second squared", "{0} meters per second squared", "Quantity.Unit.Acceleration.MetersPerSecondSquared")
+    ];
 
     internal static IEnumerable<object[]> AccelerationShortNameArgs
     {
@@ -42,6 +50,15 @@ public class AccelerationTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for acceleration units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<AccelerationUnitKeyTestData> AccelerationUnitKeyArgs =>
+        AccelerationTestDataTuples.Select(unitArgs => new AccelerationUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     [TestMethod]
     [DynamicData(nameof(AccelerationShortNameArgs))]
@@ -71,5 +88,17 @@ public class AccelerationTests
         var resultStr = acceleration.FormatAs(accelerationUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Acceleration unit will return the expected unit key.
+    /// </summary>
+    /// <param name="accelerationUnit">The acceleration unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(AccelerationUnitKeyArgs))]
+    public void GetAccelerationUnitKey_ValidUnit_ReturnsUnitKey(Unit<Acceleration> accelerationUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, accelerationUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/AngleTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AngleTests.cs
@@ -1,29 +1,57 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using AngleTestData = (Unit<Angle> unit, string shortName, string longNameSingle, string longNamePlural);
+using AngleTestData = QuantityTestData<Angle>;
+using AngleUnitKeyTestData = (Unit<Angle> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class AngleTests
 {
-    internal static AngleTestData[] AngleTestDataTuples
-    {
-        get => new AngleTestData[]
-        {
-            new (Angle.Radian, "{0} rad", "1 radian", "{0} radians"),
-            new (Angle.Degree, "{0}°", "1 degree", "{0} degrees"),
-            new (Angle.ArcMinute, "{0}′", "1 arcminute", "{0} arcminutes"),
-            new (Angle.ArcSecond, "{0}″", "1 arcsecond", "{0} arcseconds"),
-            new (SI<Angle>.Centi, "{0} crad", "1 centiradian", "{0} centiradians"),
-            new (SI<Angle>.Deca, "{0} darad", "1 decaradian", "{0} decaradians"),
-            new (SI<Angle>.Deci, "{0} drad", "1 deciradian", "{0} deciradians"),
-            new (SI<Angle>.Hecto, "{0} hrad", "1 hectoradian", "{0} hectoradians")
-        };
-    }
+    /// <summary>
+    /// An array of test data tuples representing different angle units and their display formats. Each
+    /// element in the array contains information about a angle unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static AngleTestData[] AngleTestDataTuples =>
+    [
+        new (Angle.Radian, "{0} rad", "1 radian", "{0} radians", "Quantity.Unit.Angle.Radians"),
+        new (Angle.Degree, "{0}°", "1 degree", "{0} degrees", "Quantity.Unit.Angle.Degrees"),
+        new (Angle.ArcMinute, "{0}′", "1 arcminute", "{0} arcminutes", "Quantity.Unit.Angle.Arcminutes"),
+        new (Angle.ArcSecond, "{0}″", "1 arcsecond", "{0} arcseconds", "Quantity.Unit.Angle.Arcseconds"),
+        new (SI<Angle>.Quecto, "{0} qrad", "1 quectoradian", "{0} quectoradians", "Quantity.Unit.Angle.Quectoradians"),
+        new (SI<Angle>.Ronto, "{0} rrad", "1 rontoradian", "{0} rontoradians", "Quantity.Unit.Angle.Rontoradians"),
+        new (SI<Angle>.Yocto, "{0} yrad", "1 yoctoradian", "{0} yoctoradians", "Quantity.Unit.Angle.Yoctoradians"),
+        new (SI<Angle>.Zepto, "{0} zrad", "1 zeptoradian", "{0} zeptoradians", "Quantity.Unit.Angle.Zeptoradians"),
+        new (SI<Angle>.Atto, "{0} arad", "1 attoradian", "{0} attoradians", "Quantity.Unit.Angle.Attoradians"),
+        new (SI<Angle>.Femto, "{0} frad", "1 femtoradian", "{0} femtoradians", "Quantity.Unit.Angle.Femtoradians"),
+        new (SI<Angle>.Pico, "{0} prad", "1 picoradian", "{0} picoradians", "Quantity.Unit.Angle.Picoradians"),
+        new (SI<Angle>.Nano, "{0} nrad", "1 nanoradian", "{0} nanoradians", "Quantity.Unit.Angle.Nanoradians"),
+        new (SI<Angle>.Micro, "{0} µrad", "1 microradian", "{0} microradians", "Quantity.Unit.Angle.Microradians"),
+        new (SI<Angle>.Centi, "{0} crad", "1 centiradian", "{0} centiradians", "Quantity.Unit.Angle.Centiradians"),
+        new (SI<Angle>.Deci, "{0} drad", "1 deciradian", "{0} deciradians", "Quantity.Unit.Angle.Deciradians"),
+        new (SI<Angle>.Deca, "{0} darad", "1 decaradian", "{0} decaradians", "Quantity.Unit.Angle.Decaradians"),
+        new (SI<Angle>.Hecto, "{0} hrad", "1 hectoradian", "{0} hectoradians", "Quantity.Unit.Angle.Hectoradians"),
+        new (SI<Angle>.Milli, "{0} mrad", "1 milliradian", "{0} milliradians", "Quantity.Unit.Angle.Milliradians"),
+        new (SI<Angle>.Kilo, "{0} krad", "1 kiloradian", "{0} kiloradians", "Quantity.Unit.Angle.Kiloradians"),
+        new (SI<Angle>.Mega, "{0} Mrad", "1 megaradian", "{0} megaradians", "Quantity.Unit.Angle.Megaradians"),
+        new (SI<Angle>.Giga, "{0} Grad", "1 gigaradian", "{0} gigaradians", "Quantity.Unit.Angle.Gigaradians"),
+        new (SI<Angle>.Tera, "{0} Trad", "1 teraradian", "{0} teraradians", "Quantity.Unit.Angle.Teraradians"),
+        new (SI<Angle>.Peta, "{0} Prad", "1 petaradian", "{0} petaradians", "Quantity.Unit.Angle.Petaradians"),
+        new (SI<Angle>.Exa, "{0} Erad", "1 exaradian", "{0} exaradians", "Quantity.Unit.Angle.Exaradians"),
+        new (SI<Angle>.Zetta, "{0} Zrad", "1 zettaradian", "{0} zettaradians", "Quantity.Unit.Angle.Zettaradians"),
+        new (SI<Angle>.Yotta, "{0} Yrad", "1 yottaradian", "{0} yottaradians", "Quantity.Unit.Angle.Yottaradians"),
+        new (SI<Angle>.Ronna, "{0} Rrad", "1 ronnaradian", "{0} ronnaradians", "Quantity.Unit.Angle.Ronnaradians"),
+        new (SI<Angle>.Quetta, "{0} Qrad", "1 quettaradian", "{0} quettaradians", "Quantity.Unit.Angle.Quettaradians")
+    ];
 
     internal static IEnumerable<object[]> AngleShortNameArgs
     {
@@ -67,6 +95,15 @@ public class AngleTests
             [Angle.DegreeMinSec, Math.PI/180d + Math.PI/10800d + Math.PI/648000d, "1°1′1″"]
         };
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for angle units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<AngleUnitKeyTestData> AngleUnitKeyArgs =>
+        AngleTestDataTuples.Select(unitArgs => new AngleUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     [TestMethod]
     [DynamicData(nameof(AngleShortNameArgs))]
@@ -138,4 +175,15 @@ public class AngleTests
         Assert.AreEqual(radians, angle.BaseValue, 0.0001);
     }
 
+    /// <summary>
+    /// Verifies that getting a unit key from an Angle unit will return the expected unit key.
+    /// </summary>
+    /// <param name="angleUnit">The angle unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(AngleUnitKeyArgs))]
+    public void GetAngleUnitKey_ValidUnit_ReturnsUnitKey(Unit<Angle> angleUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, angleUnit.UnitKey);
+    }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/DensityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DensityTests.cs
@@ -1,31 +1,31 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using DensityTestData = (Unit<Density> unit, string shortName, string longNameSingle, string longNamePlural);
+using DensityTestData = QuantityTestData<Density>;
+using DensityUnitKeyTestData = (Unit<Density> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class DensityTests
 {
     /// <summary>
     /// An array of test data tuples representing different density units and their display formats. Each
     /// element in the array contains information about a density unit, the short name, the singular
-    /// long name, and plural long name.
+    /// long name, plural long name, and unit key.
     /// </summary>
     /// <remarks>
     /// This property is intended for use in unit tests.
     /// </remarks>
-    internal static DensityTestData[] DensityTestDataTuples
-    {
-        get =>
-        [
-            new (Density.KilogramPerCubicMeter, "{0} kg/m³", "1 kilogram per cubic meter", "{0} kilograms per cubic meter"),
-            new (Density.GramPerCubicCentimeter, "{0} g/cm³", "1 gram per cubic centimeter", "{0} grams per cubic centimeter"),
-            new (Density.PoundPerCubicFoot, "{0} lb/ft³", "1 pound per cubic foot", "{0} pounds per cubic foot")
-        ];
-    }
+    internal static DensityTestData[] DensityTestDataTuples =>
+    [
+        new (Density.KilogramPerCubicMeter, "{0} kg/m³", "1 kilogram per cubic meter", "{0} kilograms per cubic meter", "Quantity.Unit.Density.KilogramsPerCubicMeter"),
+        new (Density.GramPerCubicCentimeter, "{0} g/cm³", "1 gram per cubic centimeter", "{0} grams per cubic centimeter", "Quantity.Unit.Density.GramsPerCubicCentimeter"),
+        new (Density.PoundPerCubicFoot, "{0} lb/ft³", "1 pound per cubic foot", "{0} pounds per cubic foot", "Quantity.Unit.Density.PoundsPerCubicFoot")
+    ];
 
     /// <summary>
     /// A collection of test data containing the density unit, the numeric value, and the expected
@@ -72,6 +72,15 @@ public class DensityTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for density units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<DensityUnitKeyTestData> DensityUnitKeyArgs =>
+        DensityTestDataTuples.Select(unitArgs => new DensityUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     /// <summary>
     /// Verifies that formatting a Density quantity using the specified unit and the default short name produces the
@@ -134,5 +143,17 @@ public class DensityTests
         var resultStr = density.FormatAs(densityUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Density unit will return the expected unit key.
+    /// </summary>
+    /// <param name="densityUnit">The density unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(DensityUnitKeyArgs))]
+    public void GetDensityUnitKey_ValidUnit_ReturnsUnitKey(Unit<Density> densityUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, densityUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
@@ -1,43 +1,67 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using DistanceTestData = (Unit<Distance> unit, string shortName, string longNameSingle, string longNamePlural);
+using DistanceTestData = QuantityTestData<Distance>;
+using DistanceUnitKeyTestData = (Unit<Distance> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class DistanceTests
 {
-    internal static DistanceTestData[] DistanceTestDataTuples
-    {
-        get => new DistanceTestData[]
-        {
-            new (Distance.AU, "{0} AU", "1 Astronomical Unit", "{0} Astronomical Units"),
-            new (Distance.Angstrom, "{0} Å", "1 ångström", "{0} ångströms"),
-            new (Distance.Foot, "{0} ft", "1 foot", "{0} feet"),
-            new (Distance.Inch, "{0} in", "1 inch", "{0} inches"),
-            new (Distance.Lightsecond, "{0} ls", "1 lightsecond", "{0} lightseconds"),
-            new (Distance.Lightyear, "{0} ly", "1 lightyear", "{0} lightyears"),
-            new (Distance.Meter, "{0} m", "1 meter", "{0} meters"),
-            new (Distance.Mile, "{0} mi", "1 mile", "{0} miles"),
-            new (Distance.Parsec, "{0} pc", "1 parsec", "{0} parsecs"),
-            new (Distance.SolarRadius, "{0} R☉", "1 Solar radius", "{0} Solar radii"),
-            new (Distance.Thou, "{0} th", "1 thou", "{0} thous"),
-            new (Distance.Yard, "{0} yd", "1 yard", "{0} yards"),
-            new (Distance.NauticalMile, "{0} NM", "1 nautical mile", "{0} nautical miles"),
-            new (Distance.Fathom, "{0} ftm", "1 fathom", "{0} fathoms"),
-            new (SI<Distance>.Kilo, "{0} km", "1 kilometer", "{0} kilometers"),
-            new (SI<Distance>.Centi, "{0} cm", "1 centimeter", "{0} centimeters"),
-            new (SI<Distance>.Milli, "{0} mm", "1 millimeter", "{0} millimeters"),
-            new (SI<Distance>.Micro, "{0} µm", "1 micrometer", "{0} micrometers"),
-            new (SI<Distance>.Nano, "{0} nm", "1 nanometer", "{0} nanometers"),
-            new (SI<Distance>.Pico, "{0} pm", "1 picometer", "{0} picometers"),
-            new (SI<Distance>.Femto, "{0} fm", "1 femtometer", "{0} femtometers"),
-            new (SI<Distance>.Atto, "{0} am", "1 attometer", "{0} attometers")
-        };
-    }
+    /// <summary>
+    /// An array of test data tuples representing different distance units and their display formats. Each
+    /// element in the array contains information about a distance unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static DistanceTestData[] DistanceTestDataTuples =>
+    [
+        new (Distance.AU, "{0} AU", "1 Astronomical Unit", "{0} Astronomical Units", "Quantity.Unit.Distance.AstronomicalUnits"),
+        new (Distance.Angstrom, "{0} Å", "1 ångström", "{0} ångströms", "Quantity.Unit.Distance.Ångströms"),
+        new (Distance.Foot, "{0} ft", "1 foot", "{0} feet", "Quantity.Unit.Distance.Feet"),
+        new (Distance.Inch, "{0} in", "1 inch", "{0} inches", "Quantity.Unit.Distance.Inches"),
+        new (Distance.Lightsecond, "{0} ls", "1 lightsecond", "{0} lightseconds", "Quantity.Unit.Distance.Lightseconds"),
+        new (Distance.Lightyear, "{0} ly", "1 lightyear", "{0} lightyears", "Quantity.Unit.Distance.Lightyears"),
+        new (Distance.Meter, "{0} m", "1 meter", "{0} meters", "Quantity.Unit.Distance.Meters"),
+        new (Distance.Mile, "{0} mi", "1 mile", "{0} miles", "Quantity.Unit.Distance.Miles"),
+        new (Distance.Parsec, "{0} pc", "1 parsec", "{0} parsecs", "Quantity.Unit.Distance.Parsecs"),
+        new (Distance.SolarRadius, "{0} R☉", "1 Solar radius", "{0} Solar radii", "Quantity.Unit.Distance.SolarRadii"),
+        new (Distance.Thou, "{0} th", "1 thou", "{0} thous", "Quantity.Unit.Distance.Thous"),
+        new (Distance.Yard, "{0} yd", "1 yard", "{0} yards", "Quantity.Unit.Distance.Yards"),
+        new (Distance.NauticalMile, "{0} NM", "1 nautical mile", "{0} nautical miles", "Quantity.Unit.Distance.NauticalMiles"),
+        new (Distance.Fathom, "{0} ftm", "1 fathom", "{0} fathoms", "Quantity.Unit.Distance.Fathoms"),
+        new (SI<Distance>.Quecto, "{0} qm", "1 quectometer", "{0} quectometers", "Quantity.Unit.Distance.Quectometers"),
+        new (SI<Distance>.Ronto, "{0} rm", "1 rontometer", "{0} rontometers", "Quantity.Unit.Distance.Rontometers"),
+        new (SI<Distance>.Yocto, "{0} ym", "1 yoctometer", "{0} yoctometers", "Quantity.Unit.Distance.Yoctometers"),
+        new (SI<Distance>.Zepto, "{0} zm", "1 zeptometer", "{0} zeptometers", "Quantity.Unit.Distance.Zeptometers"),
+        new (SI<Distance>.Atto, "{0} am", "1 attometer", "{0} attometers", "Quantity.Unit.Distance.Attometers"),
+        new (SI<Distance>.Femto, "{0} fm", "1 femtometer", "{0} femtometers", "Quantity.Unit.Distance.Femtometers"),
+        new (SI<Distance>.Pico, "{0} pm", "1 picometer", "{0} picometers", "Quantity.Unit.Distance.Picometers"),
+        new (SI<Distance>.Nano, "{0} nm", "1 nanometer", "{0} nanometers", "Quantity.Unit.Distance.Nanometers"),
+        new (SI<Distance>.Micro, "{0} µm", "1 micrometer", "{0} micrometers", "Quantity.Unit.Distance.Micrometers"),
+        new (SI<Distance>.Centi, "{0} cm", "1 centimeter", "{0} centimeters", "Quantity.Unit.Distance.Centimeters"),
+        new (SI<Distance>.Deci, "{0} dm", "1 decimeter", "{0} decimeters", "Quantity.Unit.Distance.Decimeters"),
+        new (SI<Distance>.Deca, "{0} dam", "1 decameter", "{0} decameters", "Quantity.Unit.Distance.Decameters"),
+        new (SI<Distance>.Hecto, "{0} hm", "1 hectometer", "{0} hectometers", "Quantity.Unit.Distance.Hectometers"),
+        new (SI<Distance>.Milli, "{0} mm", "1 millimeter", "{0} millimeters", "Quantity.Unit.Distance.Millimeters"),
+        new (SI<Distance>.Kilo, "{0} km", "1 kilometer", "{0} kilometers", "Quantity.Unit.Distance.Kilometers"),
+        new (SI<Distance>.Mega, "{0} Mm", "1 megameter", "{0} megameters", "Quantity.Unit.Distance.Megameters"),
+        new (SI<Distance>.Giga, "{0} Gm", "1 gigameter", "{0} gigameters", "Quantity.Unit.Distance.Gigameters"),
+        new (SI<Distance>.Tera, "{0} Tm", "1 terameter", "{0} terameters", "Quantity.Unit.Distance.Terameters"),
+        new (SI<Distance>.Peta, "{0} Pm", "1 petameter", "{0} petameters", "Quantity.Unit.Distance.Petameters"),
+        new (SI<Distance>.Exa, "{0} Em", "1 exameter", "{0} exameters", "Quantity.Unit.Distance.Exameters"),
+        new (SI<Distance>.Zetta, "{0} Zm", "1 zettameter", "{0} zettameters", "Quantity.Unit.Distance.Zettameters"),
+        new (SI<Distance>.Yotta, "{0} Ym", "1 yottameter", "{0} yottameters", "Quantity.Unit.Distance.Yottameters"),
+        new (SI<Distance>.Ronna, "{0} Rm", "1 ronnameter", "{0} ronnameters", "Quantity.Unit.Distance.Ronnameters"),
+        new (SI<Distance>.Quetta, "{0} Qm", "1 quettameter", "{0} quettameters", "Quantity.Unit.Distance.Quettameters")
+    ];
 
     internal static IEnumerable<object[]> DistanceShortNameArgs
     {
@@ -74,6 +98,15 @@ public class DistanceTests
             [Distance.FeetInches, .3302d, "1'1\""]
         };
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for distance units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<DistanceUnitKeyTestData> DistanceUnitKeyArgs =>
+        DistanceTestDataTuples.Select(unitArgs => new DistanceUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     [TestMethod]
     [DynamicData(nameof(DistanceShortNameArgs))]
@@ -113,5 +146,17 @@ public class DistanceTests
         var resultStr = distance.FormatCompound(distanceCompoundFormatInfo);
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Distance unit will return the expected unit key.
+    /// </summary>
+    /// <param name="distanceUnit">The distance unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(DistanceUnitKeyArgs))]
+    public void GetDistanceUnitKey_ValidUnit_ReturnsUnitKey(Unit<Distance> distanceUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, distanceUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/LuminanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/LuminanceTests.cs
@@ -1,30 +1,30 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using LuminanceTestData = (Unit<Luminance> unit, string shortName, string longNameSingle, string longNamePlural);
+using LuminanceTestData = QuantityTestData<Luminance>;
+using LuminanceUnitKeyTestData = (Unit<Luminance> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class LuminanceTests
 {
     /// <summary>
     /// An array of test data tuples representing different luminance units and their display formats. Each
     /// element in the array contains information about a luminance unit, the short name, the singular
-    /// long name, and plural long name.
+    /// long name, plural long name, and unit key.
     /// </summary>
     /// <remarks>
     /// This property is intended for use in unit tests.
     /// </remarks>
-    internal static LuminanceTestData[] LuminanceTestDataTuples
-    {
-        get =>
-        [
-            new (Luminance.CandelaPerSquareMeter, "{0} cd/m²", "1 candela per square meter", "{0} candelas per square meter"),
-            new (Luminance.Nit, "{0} nt", "1 nit", "{0} nits")
-        ];
-    }
+    internal static LuminanceTestData[] LuminanceTestDataTuples =>
+    [
+        new (Luminance.CandelaPerSquareMeter, "{0} cd/m²", "1 candela per square meter", "{0} candelas per square meter", "Quantity.Unit.Luminance.CandelasPerSquareMeter"),
+        new (Luminance.Nit, "{0} nt", "1 nit", "{0} nits", "Quantity.Unit.Luminance.Nits")
+    ];
 
     /// <summary>
     /// A collection of test data containing the luminance unit, the numeric value, and the expected
@@ -71,6 +71,15 @@ public class LuminanceTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for luminance units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<LuminanceUnitKeyTestData> LuminanceUnitKeyArgs =>
+        LuminanceTestDataTuples.Select(unitArgs => new LuminanceUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     /// <summary>
     /// Verifies that formatting a Luminance quantity using the specified unit and the default short name produces the
@@ -133,5 +142,17 @@ public class LuminanceTests
         var resultStr = luminance.FormatAs(luminanceUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Luminance unit will return the expected unit key.
+    /// </summary>
+    /// <param name="luminanceUnit">The luminance unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(LuminanceUnitKeyArgs))]
+    public void GetLuminanceUnitKey_ValidUnit_ReturnsUnitKey(Unit<Luminance> luminanceUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, luminanceUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/MassTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/MassTests.cs
@@ -1,39 +1,60 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using MassTestData = (Unit<Mass> unit, string shortName, string longNameSingle, string longNamePlural);
+using MassTestData = QuantityTestData<Mass>;
+using MassUnitKeyTestData = (Unit<Mass> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class MassTests
 {
-    internal static MassTestData[] MassTestDataTuples
-    {
-        get => new MassTestData[]
-        {
-            new (Mass.Gram, "{0} g", "1 gram", "{0} grams"),
-            new (Mass.Ton, "{0} t", "1 tonne", "{0} tonnes"),
-            new (Mass.Tonne, "{0} t", "1 tonne", "{0} tonnes"),
-            new (Mass.Grain, "{0} gr", "1 grain", "{0} grains"),
-            new (Mass.Drachm, "{0} dr", "1 drachm", "{0} drachms"),
-            new (Mass.Ounce, "{0} oz", "1 ounce", "{0} ounces"),
-            new (Mass.Pound, "{0} lb", "1 pound", "{0} pounds"),
-            new (Mass.Stone, "{0} st", "1 stone", "{0} stones"),
-            new (Mass.Quarter, "{0} qr", "1 quarter", "{0} quarters"),
-            new (Mass.HundredWeight, "{0} cwt", "1 hundredweight", "{0} hundredweights"),
-            new (Mass.ImperialTon, "{0} LT", "1 imperial ton", "{0} imperial tons"),
-            new (Mass.ShortTon, "{0} tn", "1 ton", "{0} tons"),
-            new (Mass.Slug, "{0} slug", "1 slug", "{0} slugs"),
-            new (SI<Mass>.Kilo, "{0} kg", "1 kilogram", "{0} kilograms"),
-            new (SI<Mass>.Milli, "{0} mg", "1 milligram", "{0} milligrams"),
-            new (SI<Mass>.Micro, "{0} µg", "1 microgram", "{0} micrograms"),
-            new (SI<Mass>.Nano, "{0} ng", "1 nanogram", "{0} nanograms"),
-            new (SI<Mass>.Pico, "{0} pg", "1 picogram", "{0} picograms"),
-        };
-    }
+    internal static MassTestData[] MassTestDataTuples =>
+    [
+        new (Mass.Gram, "{0} g", "1 gram", "{0} grams", "Quantity.Unit.Mass.Grams"),
+#pragma warning disable CS0618 // Type or member is obsolete
+        new (Mass.Ton, "{0} t", "1 tonne", "{0} tonnes", "Quantity.Unit.Mass.Tonnes"),
+#pragma warning restore CS0618 // Type or member is obsolete
+        new (Mass.Tonne, "{0} t", "1 tonne", "{0} tonnes", "Quantity.Unit.Mass.Tonnes"),
+        new (Mass.Grain, "{0} gr", "1 grain", "{0} grains", "Quantity.Unit.Mass.Grains"),
+        new (Mass.Drachm, "{0} dr", "1 drachm", "{0} drachms", "Quantity.Unit.Mass.Drachms"),
+        new (Mass.Ounce, "{0} oz", "1 ounce", "{0} ounces", "Quantity.Unit.Mass.Ounces"),
+        new (Mass.Pound, "{0} lb", "1 pound", "{0} pounds", "Quantity.Unit.Mass.Pounds"),
+        new (Mass.Stone, "{0} st", "1 stone", "{0} stones", "Quantity.Unit.Mass.Stones"),
+        new (Mass.Quarter, "{0} qr", "1 quarter", "{0} quarters", "Quantity.Unit.Mass.Quarters"),
+        new (Mass.HundredWeight, "{0} cwt", "1 hundredweight", "{0} hundredweights", "Quantity.Unit.Mass.Hundredweights"),
+        new (Mass.ImperialTon, "{0} LT", "1 imperial ton", "{0} imperial tons", "Quantity.Unit.Mass.ImperialTons"),
+        new (Mass.ShortTon, "{0} tn", "1 ton", "{0} tons", "Quantity.Unit.Mass.Tons"),
+        new (Mass.Slug, "{0} slug", "1 slug", "{0} slugs", "Quantity.Unit.Mass.Slugs"),
+        new (SI<Mass>.Quecto, "{0} qg", "1 quectogram", "{0} quectograms", "Quantity.Unit.Mass.Quectograms"),
+        new (SI<Mass>.Ronto, "{0} rg", "1 rontogram", "{0} rontograms", "Quantity.Unit.Mass.Rontograms"),
+        new (SI<Mass>.Yocto, "{0} yg", "1 yoctogram", "{0} yoctograms", "Quantity.Unit.Mass.Yoctograms"),
+        new (SI<Mass>.Zepto, "{0} zg", "1 zeptogram", "{0} zeptograms", "Quantity.Unit.Mass.Zeptograms"),
+        new (SI<Mass>.Atto, "{0} ag", "1 attogram", "{0} attograms", "Quantity.Unit.Mass.Attograms"),
+        new (SI<Mass>.Femto, "{0} fg", "1 femtogram", "{0} femtograms", "Quantity.Unit.Mass.Femtograms"),
+        new (SI<Mass>.Pico, "{0} pg", "1 picogram", "{0} picograms", "Quantity.Unit.Mass.Picograms"),
+        new (SI<Mass>.Nano, "{0} ng", "1 nanogram", "{0} nanograms", "Quantity.Unit.Mass.Nanograms"),
+        new (SI<Mass>.Micro, "{0} µg", "1 microgram", "{0} micrograms", "Quantity.Unit.Mass.Micrograms"),
+        new (SI<Mass>.Centi, "{0} cg", "1 centigram", "{0} centigrams", "Quantity.Unit.Mass.Centigrams"),
+        new (SI<Mass>.Deci, "{0} dg", "1 decigram", "{0} decigrams", "Quantity.Unit.Mass.Decigrams"),
+        new (SI<Mass>.Deca, "{0} dag", "1 decagram", "{0} decagrams", "Quantity.Unit.Mass.Decagrams"),
+        new (SI<Mass>.Hecto, "{0} hg", "1 hectogram", "{0} hectograms", "Quantity.Unit.Mass.Hectograms"),
+        new (SI<Mass>.Milli, "{0} mg", "1 milligram", "{0} milligrams", "Quantity.Unit.Mass.Milligrams"),
+        new (SI<Mass>.Kilo, "{0} kg", "1 kilogram", "{0} kilograms", "Quantity.Unit.Mass.Kilograms"),
+        new (SI<Mass>.Mega, "{0} Mg", "1 megagram", "{0} megagrams", "Quantity.Unit.Mass.Megagrams"),
+        new (SI<Mass>.Giga, "{0} Gg", "1 gigagram", "{0} gigagrams", "Quantity.Unit.Mass.Gigagrams"),
+        new (SI<Mass>.Tera, "{0} Tg", "1 teragram", "{0} teragrams", "Quantity.Unit.Mass.Teragrams"),
+        new (SI<Mass>.Peta, "{0} Pg", "1 petagram", "{0} petagrams", "Quantity.Unit.Mass.Petagrams"),
+        new (SI<Mass>.Exa, "{0} Eg", "1 exagram", "{0} exagrams", "Quantity.Unit.Mass.Exagrams"),
+        new (SI<Mass>.Zetta, "{0} Zg", "1 zettagram", "{0} zettagrams", "Quantity.Unit.Mass.Zettagrams"),
+        new (SI<Mass>.Yotta, "{0} Yg", "1 yottagram", "{0} yottagrams", "Quantity.Unit.Mass.Yottagrams"),
+        new (SI<Mass>.Ronna, "{0} Rg", "1 ronnagram", "{0} ronnagrams", "Quantity.Unit.Mass.Ronnagrams"),
+        new (SI<Mass>.Quetta, "{0} Qg", "1 quettagram", "{0} quettagrams", "Quantity.Unit.Mass.Quettagrams")
+    ];
 
     internal static IEnumerable<object[]> MassShortNameArgs
     {
@@ -59,6 +80,15 @@ public class MassTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for mass units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<MassUnitKeyTestData> MassUnitKeyArgs =>
+        MassTestDataTuples.Select(unitArgs => new MassUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     [TestMethod]
     [DynamicData(nameof(MassShortNameArgs))]
@@ -88,5 +118,17 @@ public class MassTests
         var resultStr = mass.FormatAs(massUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Mass unit will return the expected unit key.
+    /// </summary>
+    /// <param name="massUnit">The mass unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(MassUnitKeyArgs))]
+    public void GetMassUnitKey_ValidUnit_ReturnsUnitKey(Unit<Mass> massUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, massUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/PressureTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/PressureTests.cs
@@ -1,12 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using PressureTestData = (Unit<Pressure> unit, string shortName, string longNameSingle, string longNamePlural);
+using PressureTestData = QuantityTestData<Pressure>;
+using PressureUnitKeyTestData = (Unit<Pressure> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class PressureTests
 {
     /// <summary>
@@ -17,42 +20,39 @@ public class PressureTests
     /// <remarks>
     /// This property is intended for use in unit tests.
     /// </remarks>
-    internal static PressureTestData[] PressureTestDataTuples
-    {
-        get =>
-        [
-            new (Pressure.Pascal, "{0} Pa", "1 pascal", "{0} pascals"),
-            new (Pressure.Bar, "{0} bar", "1 bar", "{0} bars"),
-            new (Pressure.Atmosphere, "{0} atm", "1 standard atmosphere", "{0} standard atmospheres"),
-            new (Pressure.Torr, "{0} Torr", "1 torr", "{0} torrs"),
-            new (Pressure.Millibar, "{0} mbar", "1 millibar", "{0} millibars"),
-            new (Pressure.PoundPerSquareInch, "{0} psi", "1 pound per square inch", "{0} pounds per square inch"),
-            new (SI<Pressure>.Quecto, "{0} qPa", "1 quectopascal", "{0} quectopascals"),
-            new (SI<Pressure>.Ronto, "{0} rPa", "1 rontopascal", "{0} rontopascals"),
-            new (SI<Pressure>.Yocto, "{0} yPa", "1 yoctopascal", "{0} yoctopascals"),
-            new (SI<Pressure>.Zepto, "{0} zPa", "1 zeptopascal", "{0} zeptopascals"),
-            new (SI<Pressure>.Atto, "{0} aPa", "1 attopascal", "{0} attopascals"),
-            new (SI<Pressure>.Femto, "{0} fPa", "1 femtopascal", "{0} femtopascals"),
-            new (SI<Pressure>.Pico, "{0} pPa", "1 picopascal", "{0} picopascals"),
-            new (SI<Pressure>.Nano, "{0} nPa", "1 nanopascal", "{0} nanopascals"),
-            new (SI<Pressure>.Micro, "{0} µPa", "1 micropascal", "{0} micropascals"),
-            new (SI<Pressure>.Milli, "{0} mPa", "1 millipascal", "{0} millipascals"),
-            new (SI<Pressure>.Centi, "{0} cPa", "1 centipascal", "{0} centipascals"),
-            new (SI<Pressure>.Deci, "{0} dPa", "1 decipascal", "{0} decipascals"),
-            new (SI<Pressure>.Deca, "{0} daPa", "1 decapascal", "{0} decapascals"),
-            new (SI<Pressure>.Hecto, "{0} hPa", "1 hectopascal", "{0} hectopascals"),
-            new (SI<Pressure>.Kilo, "{0} kPa", "1 kilopascal", "{0} kilopascals"),
-            new (SI<Pressure>.Mega, "{0} MPa", "1 megapascal", "{0} megapascals"),
-            new (SI<Pressure>.Giga, "{0} GPa", "1 gigapascal", "{0} gigapascals"),
-            new (SI<Pressure>.Tera, "{0} TPa", "1 terapascal", "{0} terapascals"),
-            new (SI<Pressure>.Peta, "{0} PPa", "1 petapascal", "{0} petapascals"),
-            new (SI<Pressure>.Exa, "{0} EPa", "1 exapascal", "{0} exapascals"),
-            new (SI<Pressure>.Zetta, "{0} ZPa", "1 zettapascal", "{0} zettapascals"),
-            new (SI<Pressure>.Yotta, "{0} YPa", "1 yottapascal", "{0} yottapascals"),
-            new (SI<Pressure>.Ronna, "{0} RPa", "1 ronnapascal", "{0} ronnapascals"),
-            new (SI<Pressure>.Quetta, "{0} QPa", "1 quettapascal", "{0} quettapascals")
-        ];
-    }
+    internal static PressureTestData[] PressureTestDataTuples =>
+    [
+        new (Pressure.Pascal, "{0} Pa", "1 pascal", "{0} pascals", "Quantity.Unit.Pressure.Pascals"),
+        new (Pressure.Bar, "{0} bar", "1 bar", "{0} bars", "Quantity.Unit.Pressure.Bars"),
+        new (Pressure.Atmosphere, "{0} atm", "1 standard atmosphere", "{0} standard atmospheres", "Quantity.Unit.Pressure.StandardAtmospheres"),
+        new (Pressure.Torr, "{0} Torr", "1 torr", "{0} torrs", "Quantity.Unit.Pressure.Torrs"),
+        new (Pressure.Millibar, "{0} mbar", "1 millibar", "{0} millibars", "Quantity.Unit.Pressure.Millibars"),
+        new (Pressure.PoundPerSquareInch, "{0} psi", "1 pound per square inch", "{0} pounds per square inch", "Quantity.Unit.Pressure.PoundsPerSquareInch"),
+        new (SI<Pressure>.Quecto, "{0} qPa", "1 quectopascal", "{0} quectopascals", "Quantity.Unit.Pressure.Quectopascals"),
+        new (SI<Pressure>.Ronto, "{0} rPa", "1 rontopascal", "{0} rontopascals", "Quantity.Unit.Pressure.Rontopascals"),
+        new (SI<Pressure>.Yocto, "{0} yPa", "1 yoctopascal", "{0} yoctopascals", "Quantity.Unit.Pressure.Yoctopascals"),
+        new (SI<Pressure>.Zepto, "{0} zPa", "1 zeptopascal", "{0} zeptopascals", "Quantity.Unit.Pressure.Zeptopascals"),
+        new (SI<Pressure>.Atto, "{0} aPa", "1 attopascal", "{0} attopascals", "Quantity.Unit.Pressure.Attopascals"),
+        new (SI<Pressure>.Femto, "{0} fPa", "1 femtopascal", "{0} femtopascals", "Quantity.Unit.Pressure.Femtopascals"),
+        new (SI<Pressure>.Pico, "{0} pPa", "1 picopascal", "{0} picopascals", "Quantity.Unit.Pressure.Picopascals"),
+        new (SI<Pressure>.Nano, "{0} nPa", "1 nanopascal", "{0} nanopascals", "Quantity.Unit.Pressure.Nanopascals"),
+        new (SI<Pressure>.Micro, "{0} µPa", "1 micropascal", "{0} micropascals", "Quantity.Unit.Pressure.Micropascals"),
+        new (SI<Pressure>.Milli, "{0} mPa", "1 millipascal", "{0} millipascals", "Quantity.Unit.Pressure.Millipascals"),
+        new (SI<Pressure>.Centi, "{0} cPa", "1 centipascal", "{0} centipascals", "Quantity.Unit.Pressure.Centipascals"),
+        new (SI<Pressure>.Deci, "{0} dPa", "1 decipascal", "{0} decipascals", "Quantity.Unit.Pressure.Decipascals"),
+        new (SI<Pressure>.Deca, "{0} daPa", "1 decapascal", "{0} decapascals", "Quantity.Unit.Pressure.Decapascals"),
+        new (SI<Pressure>.Hecto, "{0} hPa", "1 hectopascal", "{0} hectopascals", "Quantity.Unit.Pressure.Hectopascals"),
+        new (SI<Pressure>.Kilo, "{0} kPa", "1 kilopascal", "{0} kilopascals", "Quantity.Unit.Pressure.Kilopascals"),
+        new (SI<Pressure>.Mega, "{0} MPa", "1 megapascal", "{0} megapascals", "Quantity.Unit.Pressure.Megapascals"),
+        new (SI<Pressure>.Giga, "{0} GPa", "1 gigapascal", "{0} gigapascals", "Quantity.Unit.Pressure.Gigapascals"),
+        new (SI<Pressure>.Tera, "{0} TPa", "1 terapascal", "{0} terapascals", "Quantity.Unit.Pressure.Terapascals"),
+        new (SI<Pressure>.Peta, "{0} PPa", "1 petapascal", "{0} petapascals", "Quantity.Unit.Pressure.Petapascals"),
+        new (SI<Pressure>.Exa, "{0} EPa", "1 exapascal", "{0} exapascals", "Quantity.Unit.Pressure.Exapascals"),
+        new (SI<Pressure>.Zetta, "{0} ZPa", "1 zettapascal", "{0} zettapascals", "Quantity.Unit.Pressure.Zettapascals"),
+        new (SI<Pressure>.Yotta, "{0} YPa", "1 yottapascal", "{0} yottapascals", "Quantity.Unit.Pressure.Yottapascals"),
+        new (SI<Pressure>.Ronna, "{0} RPa", "1 ronnapascal", "{0} ronnapascals", "Quantity.Unit.Pressure.Ronnapascals"),
+        new (SI<Pressure>.Quetta, "{0} QPa", "1 quettapascal", "{0} quettapascals", "Quantity.Unit.Pressure.Quettapascals")
+    ];
 
     /// <summary>
     /// A collection of test data containing the pressure unit, the numeric value, and the expected
@@ -99,6 +99,15 @@ public class PressureTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for pressure units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<PressureUnitKeyTestData> PressureUnitKeyArgs =>
+        PressureTestDataTuples.Select(unitArgs => new PressureUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     /// <summary>
     /// Verifies that formatting a Pressure quantity using the specified unit and the default short name produces the
@@ -161,5 +170,17 @@ public class PressureTests
         var resultStr = pressure.FormatAs(pressureUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Pressure unit will return the expected unit key.
+    /// </summary>
+    /// <param name="pressureUnit">The pressure unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(PressureUnitKeyArgs))]
+    public void GetPressureUnitKey_ValidUnit_ReturnsUnitKey(Unit<Pressure> pressureUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, pressureUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/RatioTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/RatioTests.cs
@@ -1,23 +1,31 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using RatioTestData = (Unit<Ratio> unit, string shortName, string longNameSingle, string longNamePlural);
+using RatioTestData = QuantityTestData<Ratio>;
+using RatioUnitKeyTestData = (Unit<Ratio> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class RatioTests
 {
-    internal static RatioTestData[] RatioTestDataTuples
-    {
-        get => new RatioTestData[]
-        {
-            new (Ratio.RatioValue, "{0}", "1", "{0}"),
-            new (Ratio.Percent, "{0} %", "1 percent", "{0} percent")
-        };
-    }
+    /// <summary>
+    /// An array of test data tuples representing different ratio units and their display formats. Each
+    /// element in the array contains information about a ratio unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static RatioTestData[] RatioTestDataTuples =>
+    [
+        new (Ratio.RatioValue, "{0}", "1", "{0}", "Quantity.Unit.Ratio"),
+        new (Ratio.Percent, "{0} %", "1 percent", "{0} percent", "Quantity.Unit.Ratio.Percent")
+    ];
 
     internal static IEnumerable<object[]> RatioShortNameArgs
     {
@@ -43,6 +51,15 @@ public class RatioTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for ratio units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<RatioUnitKeyTestData> RatioUnitKeyArgs =>
+        RatioTestDataTuples.Select(unitArgs => new RatioUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     [TestMethod]
     [DynamicData(nameof(RatioShortNameArgs))]
@@ -72,5 +89,17 @@ public class RatioTests
         var resultStr = ratio.FormatAs(ratioUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Ratio unit will return the expected unit key.
+    /// </summary>
+    /// <param name="ratioUnit">The ratio unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(RatioUnitKeyArgs))]
+    public void GetRatioUnitKey_ValidUnit_ReturnsUnitKey(Unit<Ratio> ratioUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, ratioUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/TemperatureTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TemperatureTests.cs
@@ -1,24 +1,31 @@
-﻿using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using TemperatureTestData = (Unit<Temperature> unit, string shortName, string longNameSingle, string longNamePlural);
+using TemperatureTestData = QuantityTestData<Temperature>;
+using TemperatureUnitKeyTestData = (Unit<Temperature> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class TemperatureTests
 {
-    internal static TemperatureTestData[] TemperatureTestDataTuples
-    {
-        get => new TemperatureTestData[]
-        {
-            new (Temperature.Kelvin, "{0} K", "1 Kelvin", "{0} Kelvins"),
-            new (Temperature.Celsius, "{0} °C", "1 degree Celsius", "{0} degrees Celsius"),
-            new (Temperature.Fahrenheit, "{0} °F", "1 degree Fahrenheit", "{0} degrees Fahrenheit")
-        };
-    }
+    /// <summary>
+    /// An array of test data tuples representing different temperature units and their display formats. Each
+    /// element in the array contains information about a temperature unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static TemperatureTestData[] TemperatureTestDataTuples =>
+    [
+        new (Temperature.Kelvin, "{0} K", "1 Kelvin", "{0} Kelvins", "Quantity.Unit.Temperature.Kelvins"),
+        new (Temperature.Celsius, "{0} °C", "1 degree Celsius", "{0} degrees Celsius", "Quantity.Unit.Temperature.Celsius"),
+        new (Temperature.Fahrenheit, "{0} °F", "1 degree Fahrenheit", "{0} degrees Fahrenheit", "Quantity.Unit.Temperature.Fahrenheit")
+    ];
 
     internal static IEnumerable<object[]> TemperatureShortNameArgs
     {
@@ -44,6 +51,15 @@ public class TemperatureTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for temperature units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<TemperatureUnitKeyTestData> TemperatureUnitKeyArgs =>
+        TemperatureTestDataTuples.Select(unitArgs => new TemperatureUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     [TestMethod]
     [DynamicData(nameof(TemperatureShortNameArgs))]
@@ -73,5 +89,17 @@ public class TemperatureTests
         var resultStr = temperature.FormatAs(temperatureUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Temperature unit will return the expected unit key.
+    /// </summary>
+    /// <param name="temperatureUnit">The temperature unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(TemperatureUnitKeyArgs))]
+    public void GetTemperatureUnitKey_ValidUnit_ReturnsUnitKey(Unit<Temperature> temperatureUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, temperatureUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/TimeTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TimeTests.cs
@@ -1,26 +1,34 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using TimeTestData = (Unit<Time> unit, string shortName, string longNameSingle, string longNamePlural);
+using TimeTestData = QuantityTestData<Time>;
+using TimeUnitKeyTestData = (Unit<Time> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class TimeTests
 {
-    internal static TimeTestData[] TimeTestDataTuples
-    {
-        get => new TimeTestData[]
-        {
-            new (Time.Millisecond, "{0} ms", "1 millisecond", "{0} milliseconds"),
-            new (Time.Second, "{0} s", "1 second", "{0} seconds"),
-            new (Time.Minute, "{0} m", "1 minute", "{0} minutes"),
-            new (Time.Hour, "{0} h", "1 hour", "{0} hours"),
-            new (Time.Day, "{0} d", "1 day", "{0} days")
-        };
-    }
+    /// <summary>
+    /// An array of test data tuples representing different time units and their display formats. Each
+    /// element in the array contains information about a time unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static TimeTestData[] TimeTestDataTuples =>
+    [
+        new (Time.Millisecond, "{0} ms", "1 millisecond", "{0} milliseconds", "Quantity.Unit.Time.Milliseconds"),
+        new (Time.Second, "{0} s", "1 second", "{0} seconds", "Quantity.Unit.Time.Seconds"),
+        new (Time.Minute, "{0} m", "1 minute", "{0} minutes", "Quantity.Unit.Time.Minutes"),
+        new (Time.Hour, "{0} h", "1 hour", "{0} hours", "Quantity.Unit.Time.Hours"),
+        new (Time.Day, "{0} d", "1 day", "{0} days", "Quantity.Unit.Time.Days")
+    ];
 
     internal static IEnumerable<object[]> TimeShortNameArgs
     {
@@ -105,6 +113,15 @@ public class TimeTests
         };
     }
 
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for time units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<TimeUnitKeyTestData> TimeUnitKeyArgs =>
+        TimeTestDataTuples.Select(unitArgs => new TimeUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
+
     [TestMethod]
     [DynamicData(nameof(TimeShortNameArgs))]
     public void TimeUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Time> timeUnit, double timeValue, string expectedStr)
@@ -143,5 +160,17 @@ public class TimeTests
         var resultStr = time.FormatCompound(timeCompoundFormatInfo);
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Time unit will return the expected unit key.
+    /// </summary>
+    /// <param name="timeUnit">The time unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(TimeUnitKeyArgs))]
+    public void GetTimeUnitKey_ValidUnit_ReturnsUnitKey(Unit<Time> timeUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, timeUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/TorqueTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TorqueTests.cs
@@ -1,30 +1,30 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using TorqueTestData = (Unit<Torque> unit, string shortName, string longNameSingle, string longNamePlural);
+using TorqueTestData = QuantityTestData<Torque>;
+using TorqueUnitKeyTestData = (Unit<Torque> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class TorqueTests
 {
     /// <summary>
     /// An array of test data tuples representing different torque units and their display formats. Each
     /// element in the array contains information about a torque unit, the short name, the singular
-    /// long name, and plural long name.
+    /// long name, plural long name, and unit key.
     /// </summary>
     /// <remarks>
     /// This property is intended for use in unit tests.
     /// </remarks>
-    internal static TorqueTestData[] TorqueTestDataTuples
-    {
-        get =>
-        [
-            new (Torque.NewtonMeter, "{0} N m", "1 newton meter", "{0} newton meters"),
-            new (Torque.PoundFoot, "{0} lb·ft", "1 pound-foot", "{0} pound-feet")
-        ];
-    }
+    internal static TorqueTestData[] TorqueTestDataTuples =>
+    [
+        new (Torque.NewtonMeter, "{0} N m", "1 newton meter", "{0} newton meters", "Quantity.Unit.Torque.NewtonMeters"),
+        new (Torque.PoundFoot, "{0} lb·ft", "1 pound-foot", "{0} pound-feet", "Quantity.Unit.Torque.Pound-feet")
+    ];
 
     /// <summary>
     /// A collection of test data containing the torque unit, the numeric value, and the expected
@@ -71,6 +71,15 @@ public class TorqueTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for torque units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<TorqueUnitKeyTestData> TorqueUnitKeyArgs =>
+        TorqueTestDataTuples.Select(unitArgs => new TorqueUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     /// <summary>
     /// Verifies that formatting a Torque quantity using the specified unit and the default short name produces the
@@ -133,5 +142,17 @@ public class TorqueTests
         var resultStr = torque.FormatAs(torqueUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Torque unit will return the expected unit key.
+    /// </summary>
+    /// <param name="torqueUnit">The torque unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(TorqueUnitKeyArgs))]
+    public void GetTorqueUnitKey_ValidUnit_ReturnsUnitKey(Unit<Torque> torqueUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, torqueUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/VelocityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/VelocityTests.cs
@@ -1,26 +1,34 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using VelocityTestData = (Unit<Velocity> unit, string shortName, string longNameSingle, string longNamePlural);
+using VelocityTestData = QuantityTestData<Velocity>;
+using VelocityUnitKeyTestData = (Unit<Velocity> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class VelocityTests
 {
-    internal static VelocityTestData[] VelocityTestDataTuples
-    {
-        get => new VelocityTestData[]
-        {
-            new (Velocity.MetersPerSecond, "{0} m/s", "1 meter per second", "{0} meters per second"),
-            new (Velocity.KilometersPerHour, "{0} km/h", "1 kilometer per hour", "{0} kilometers per hour"),
-            new (Velocity.MilesPerHour, "{0} mph", "1 mile per hour", "{0} miles per hour"),
-            new (Velocity.FeetPerSecond, "{0} ft/s", "1 foot per second", "{0} feet per second"),
-            new (Velocity.Knots, "{0} kn", "1 knot", "{0} knots")
-        };
-    }
+    /// <summary>
+    /// An array of test data tuples representing different velocity units and their display formats. Each
+    /// element in the array contains information about a velocity unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static VelocityTestData[] VelocityTestDataTuples =>
+    [
+        new (Velocity.MetersPerSecond, "{0} m/s", "1 meter per second", "{0} meters per second", "Quantity.Unit.Velocity.MetersPerSecond"),
+        new (Velocity.KilometersPerHour, "{0} km/h", "1 kilometer per hour", "{0} kilometers per hour", "Quantity.Unit.Velocity.KilometersPerHour"),
+        new (Velocity.MilesPerHour, "{0} mph", "1 mile per hour", "{0} miles per hour", "Quantity.Unit.Velocity.MilesPerHour"),
+        new (Velocity.FeetPerSecond, "{0} ft/s", "1 foot per second", "{0} feet per second", "Quantity.Unit.Velocity.FeetPerSecond"),
+        new (Velocity.Knots, "{0} kn", "1 knot", "{0} knots", "Quantity.Unit.Velocity.Knots")
+    ];
 
     internal static IEnumerable<object[]> VelocityShortNameArgs
     {
@@ -46,6 +54,15 @@ public class VelocityTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for velocity units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<VelocityUnitKeyTestData> VelocityUnitKeyArgs =>
+        VelocityTestDataTuples.Select(unitArgs => new VelocityUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     [TestMethod]
     [DynamicData(nameof(VelocityShortNameArgs))]
@@ -75,5 +92,17 @@ public class VelocityTests
         var resultStr = velocity.FormatAs(velocityUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Velocity unit will return the expected unit key.
+    /// </summary>
+    /// <param name="velocityUnit">The velocity unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(VelocityUnitKeyArgs))]
+    public void GetVelocityUnitKey_ValidUnit_ReturnsUnitKey(Unit<Velocity> velocityUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, velocityUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/CurrentTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/CurrentTests.cs
@@ -1,42 +1,54 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Electronic;
 
-using CurrentTestData = (Unit<Current> unit, string shortName, string longNameSingle, string longNamePlural);
+using CurrentTestData = QuantityTestData<Current>;
+using CurrentUnitKeyTestData = (Unit<Current> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class CurrentTests
 {
-    internal static CurrentTestData[] CurrentTestDataTuples
-    {
-        get => new CurrentTestData[]
-        {
-            new (Current.Ampere, "{0} A", "1 ampere", "{0} amperes"),
-            new (SI<Current>.Quecto, "{0} qA", "1 quectoampere", "{0} quectoamperes"),
-            new (SI<Current>.Ronto, "{0} rA", "1 rontoampere", "{0} rontoamperes"),
-            new (SI<Current>.Yocto, "{0} yA", "1 yoctoampere", "{0} yoctoamperes"),
-            new (SI<Current>.Zepto, "{0} zA", "1 zeptoampere", "{0} zeptoamperes"),
-            new (SI<Current>.Atto, "{0} aA", "1 attoampere", "{0} attoamperes"),
-            new (SI<Current>.Femto, "{0} fA", "1 femtoampere", "{0} femtoamperes"),
-            new (SI<Current>.Pico, "{0} pA", "1 picoampere", "{0} picoamperes"),
-            new (SI<Current>.Nano, "{0} nA", "1 nanoampere", "{0} nanoamperes"),
-            new (SI<Current>.Micro, "{0} µA", "1 microampere", "{0} microamperes"),
-            new (SI<Current>.Milli, "{0} mA", "1 milliampere", "{0} milliamperes"),
-            new (SI<Current>.Kilo, "{0} kA", "1 kiloampere", "{0} kiloamperes"),
-            new (SI<Current>.Mega, "{0} MA", "1 megaampere", "{0} megaamperes"),
-            new (SI<Current>.Giga, "{0} GA", "1 gigaampere", "{0} gigaamperes"),
-            new (SI<Current>.Tera, "{0} TA", "1 teraampere", "{0} teraamperes"),
-            new (SI<Current>.Peta, "{0} PA", "1 petaampere", "{0} petaamperes"),
-            new (SI<Current>.Exa, "{0} EA", "1 exaampere", "{0} exaamperes"),
-            new (SI<Current>.Zetta, "{0} ZA", "1 zettaampere", "{0} zettaamperes"),
-            new (SI<Current>.Yotta, "{0} YA", "1 yottaampere", "{0} yottaamperes"),
-            new (SI<Current>.Ronna, "{0} RA", "1 ronnaampere", "{0} ronnaamperes"),
-            new (SI<Current>.Quetta, "{0} QA", "1 quettaampere", "{0} quettaamperes")
-        };
-    }
+    /// <summary>
+    /// An array of test data tuples representing different current units and their display formats. Each
+    /// element in the array contains information about a current unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static CurrentTestData[] CurrentTestDataTuples =>
+    [
+        new(Current.Ampere, "{0} A", "1 ampere", "{0} amperes", "Quantity.Unit.Electronic.Current.Amperes"),
+        new(SI<Current>.Quecto, "{0} qA", "1 quectoampere", "{0} quectoamperes", "Quantity.Unit.Electronic.Current.Quectoamperes"),
+        new(SI<Current>.Ronto, "{0} rA", "1 rontoampere", "{0} rontoamperes", "Quantity.Unit.Electronic.Current.Rontoamperes"),
+        new(SI<Current>.Yocto, "{0} yA", "1 yoctoampere", "{0} yoctoamperes", "Quantity.Unit.Electronic.Current.Yoctoamperes"),
+        new(SI<Current>.Zepto, "{0} zA", "1 zeptoampere", "{0} zeptoamperes", "Quantity.Unit.Electronic.Current.Zeptoamperes"),
+        new(SI<Current>.Atto, "{0} aA", "1 attoampere", "{0} attoamperes", "Quantity.Unit.Electronic.Current.Attoamperes"),
+        new(SI<Current>.Femto, "{0} fA", "1 femtoampere", "{0} femtoamperes", "Quantity.Unit.Electronic.Current.Femtoamperes"),
+        new(SI<Current>.Pico, "{0} pA", "1 picoampere", "{0} picoamperes", "Quantity.Unit.Electronic.Current.Picoamperes"),
+        new(SI<Current>.Nano, "{0} nA", "1 nanoampere", "{0} nanoamperes", "Quantity.Unit.Electronic.Current.Nanoamperes"),
+        new(SI<Current>.Micro, "{0} µA", "1 microampere", "{0} microamperes", "Quantity.Unit.Electronic.Current.Microamperes"),
+        new(SI<Current>.Centi, "{0} cA", "1 centiampere", "{0} centiamperes", "Quantity.Unit.Electronic.Current.Centiamperes"),
+        new(SI<Current>.Deci, "{0} dA", "1 deciampere", "{0} deciamperes", "Quantity.Unit.Electronic.Current.Deciamperes"),
+        new(SI<Current>.Deca, "{0} daA", "1 decaampere", "{0} decaamperes", "Quantity.Unit.Electronic.Current.Decaamperes"),
+        new(SI<Current>.Hecto, "{0} hA", "1 hectoampere", "{0} hectoamperes", "Quantity.Unit.Electronic.Current.Hectoamperes"),
+        new(SI<Current>.Milli, "{0} mA", "1 milliampere", "{0} milliamperes", "Quantity.Unit.Electronic.Current.Milliamperes"),
+        new(SI<Current>.Kilo, "{0} kA", "1 kiloampere", "{0} kiloamperes", "Quantity.Unit.Electronic.Current.Kiloamperes"),
+        new(SI<Current>.Mega, "{0} MA", "1 megaampere", "{0} megaamperes", "Quantity.Unit.Electronic.Current.Megaamperes"),
+        new(SI<Current>.Giga, "{0} GA", "1 gigaampere", "{0} gigaamperes", "Quantity.Unit.Electronic.Current.Gigaamperes"),
+        new(SI<Current>.Tera, "{0} TA", "1 teraampere", "{0} teraamperes", "Quantity.Unit.Electronic.Current.Teraamperes"),
+        new(SI<Current>.Peta, "{0} PA", "1 petaampere", "{0} petaamperes", "Quantity.Unit.Electronic.Current.Petaamperes"),
+        new(SI<Current>.Exa, "{0} EA", "1 exaampere", "{0} exaamperes", "Quantity.Unit.Electronic.Current.Exaamperes"),
+        new(SI<Current>.Zetta, "{0} ZA", "1 zettaampere", "{0} zettaamperes", "Quantity.Unit.Electronic.Current.Zettaamperes"),
+        new(SI<Current>.Yotta, "{0} YA", "1 yottaampere", "{0} yottaamperes", "Quantity.Unit.Electronic.Current.Yottaamperes"),
+        new(SI<Current>.Ronna, "{0} RA", "1 ronnaampere", "{0} ronnaamperes", "Quantity.Unit.Electronic.Current.Ronnaamperes"),
+        new(SI<Current>.Quetta, "{0} QA", "1 quettaampere", "{0} quettaamperes", "Quantity.Unit.Electronic.Current.Quettaamperes")
+    ];
 
     internal static IEnumerable<object[]> CurrentShortNameArgs
     {
@@ -62,6 +74,15 @@ public class CurrentTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for current units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<CurrentUnitKeyTestData> CurrentUnitKeyArgs =>
+        CurrentTestDataTuples.Select(unitArgs => new CurrentUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     [TestMethod]
     [DynamicData(nameof(CurrentShortNameArgs))]
@@ -91,5 +112,17 @@ public class CurrentTests
         var resultStr = current.FormatAs(currentUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Current unit will return the expected unit key.
+    /// </summary>
+    /// <param name="currentUnit">The current unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(CurrentUnitKeyArgs))]
+    public void GetCurrentUnitKey_ValidUnit_ReturnsUnitKey(Unit<Current> currentUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, currentUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/ResistenceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/ResistenceTests.cs
@@ -1,42 +1,54 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Electronic;
 
-using ResistanceTestData = (Unit<Resistance> unit, string shortName, string longNameSingle, string longNamePlural);
+using ResistanceTestData = QuantityTestData<Resistance>;
+using ResistanceUnitKeyTestData = (Unit<Resistance> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class ResistanceTests
 {
-    internal static ResistanceTestData[] ResistanceTestDataTuples
-    {
-        get => new ResistanceTestData[]
-        {
-            new (Resistance.Ohm, "{0} Ω", "1 ohm", "{0} ohms"),
-            new (SI<Resistance>.Quecto, "{0} qΩ", "1 quectoohm", "{0} quectoohms"),
-            new (SI<Resistance>.Ronto, "{0} rΩ", "1 rontoohm", "{0} rontoohms"),
-            new (SI<Resistance>.Yocto, "{0} yΩ", "1 yoctoohm", "{0} yoctoohms"),
-            new (SI<Resistance>.Zepto, "{0} zΩ", "1 zeptoohm", "{0} zeptoohms"),
-            new (SI<Resistance>.Atto, "{0} aΩ", "1 attoohm", "{0} attoohms"),
-            new (SI<Resistance>.Femto, "{0} fΩ", "1 femtoohm", "{0} femtoohms"),
-            new (SI<Resistance>.Pico, "{0} pΩ", "1 picoohm", "{0} picoohms"),
-            new (SI<Resistance>.Nano, "{0} nΩ", "1 nanoohm", "{0} nanoohms"),
-            new (SI<Resistance>.Micro, "{0} µΩ", "1 microohm", "{0} microohms"),
-            new (SI<Resistance>.Milli, "{0} mΩ", "1 milliohm", "{0} milliohms"),
-            new (SI<Resistance>.Kilo, "{0} kΩ", "1 kiloohm", "{0} kiloohms"),
-            new (SI<Resistance>.Mega, "{0} MΩ", "1 megaohm", "{0} megaohms"),
-            new (SI<Resistance>.Giga, "{0} GΩ", "1 gigaohm", "{0} gigaohms"),
-            new (SI<Resistance>.Tera, "{0} TΩ", "1 teraohm", "{0} teraohms"),
-            new (SI<Resistance>.Peta, "{0} PΩ", "1 petaohm", "{0} petaohms"),
-            new (SI<Resistance>.Exa, "{0} EΩ", "1 exaohm", "{0} exaohms"),
-            new (SI<Resistance>.Zetta, "{0} ZΩ", "1 zettaohm", "{0} zettaohms"),
-            new (SI<Resistance>.Yotta, "{0} YΩ", "1 yottaohm", "{0} yottaohms"),
-            new (SI<Resistance>.Ronna, "{0} RΩ", "1 ronnaohm", "{0} ronnaohms"),
-            new (SI<Resistance>.Quetta, "{0} QΩ", "1 quettaohm", "{0} quettaohms")
-        };
-    }
+    /// <summary>
+    /// An array of test data tuples representing different resistance units and their display formats. Each
+    /// element in the array contains information about a resistance unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static ResistanceTestData[] ResistanceTestDataTuples =>
+    [
+        new (Resistance.Ohm, "{0} Ω", "1 ohm", "{0} ohms", "Quantity.Unit.Electronic.Resistance.Ohms"),
+        new (SI<Resistance>.Quecto, "{0} qΩ", "1 quectoohm", "{0} quectoohms", "Quantity.Unit.Electronic.Resistance.Quectoohms"),
+        new (SI<Resistance>.Ronto, "{0} rΩ", "1 rontoohm", "{0} rontoohms", "Quantity.Unit.Electronic.Resistance.Rontoohms"),
+        new (SI<Resistance>.Yocto, "{0} yΩ", "1 yoctoohm", "{0} yoctoohms", "Quantity.Unit.Electronic.Resistance.Yoctoohms"),
+        new (SI<Resistance>.Zepto, "{0} zΩ", "1 zeptoohm", "{0} zeptoohms", "Quantity.Unit.Electronic.Resistance.Zeptoohms"),
+        new (SI<Resistance>.Atto, "{0} aΩ", "1 attoohm", "{0} attoohms", "Quantity.Unit.Electronic.Resistance.Attoohms"),
+        new (SI<Resistance>.Femto, "{0} fΩ", "1 femtoohm", "{0} femtoohms", "Quantity.Unit.Electronic.Resistance.Femtoohms"),
+        new (SI<Resistance>.Pico, "{0} pΩ", "1 picoohm", "{0} picoohms", "Quantity.Unit.Electronic.Resistance.Picoohms"),
+        new (SI<Resistance>.Nano, "{0} nΩ", "1 nanoohm", "{0} nanoohms", "Quantity.Unit.Electronic.Resistance.Nanoohms"),
+        new (SI<Resistance>.Micro, "{0} µΩ", "1 microohm", "{0} microohms", "Quantity.Unit.Electronic.Resistance.Microohms"),
+        new (SI<Resistance>.Centi, "{0} cΩ", "1 centiohm", "{0} centiohms", "Quantity.Unit.Electronic.Resistance.Centiohms"),
+        new (SI<Resistance>.Deci, "{0} dΩ", "1 deciohm", "{0} deciohms", "Quantity.Unit.Electronic.Resistance.Deciohms"),
+        new (SI<Resistance>.Deca, "{0} daΩ", "1 decaohm", "{0} decaohms", "Quantity.Unit.Electronic.Resistance.Decaohms"),
+        new (SI<Resistance>.Hecto, "{0} hΩ", "1 hectoohm", "{0} hectoohms", "Quantity.Unit.Electronic.Resistance.Hectoohms"),
+        new (SI<Resistance>.Milli, "{0} mΩ", "1 milliohm", "{0} milliohms", "Quantity.Unit.Electronic.Resistance.Milliohms"),
+        new (SI<Resistance>.Kilo, "{0} kΩ", "1 kiloohm", "{0} kiloohms", "Quantity.Unit.Electronic.Resistance.Kiloohms"),
+        new (SI<Resistance>.Mega, "{0} MΩ", "1 megaohm", "{0} megaohms", "Quantity.Unit.Electronic.Resistance.Megaohms"),
+        new (SI<Resistance>.Giga, "{0} GΩ", "1 gigaohm", "{0} gigaohms", "Quantity.Unit.Electronic.Resistance.Gigaohms"),
+        new (SI<Resistance>.Tera, "{0} TΩ", "1 teraohm", "{0} teraohms", "Quantity.Unit.Electronic.Resistance.Teraohms"),
+        new (SI<Resistance>.Peta, "{0} PΩ", "1 petaohm", "{0} petaohms", "Quantity.Unit.Electronic.Resistance.Petaohms"),
+        new (SI<Resistance>.Exa, "{0} EΩ", "1 exaohm", "{0} exaohms", "Quantity.Unit.Electronic.Resistance.Exaohms"),
+        new (SI<Resistance>.Zetta, "{0} ZΩ", "1 zettaohm", "{0} zettaohms", "Quantity.Unit.Electronic.Resistance.Zettaohms"),
+        new (SI<Resistance>.Yotta, "{0} YΩ", "1 yottaohm", "{0} yottaohms", "Quantity.Unit.Electronic.Resistance.Yottaohms"),
+        new (SI<Resistance>.Ronna, "{0} RΩ", "1 ronnaohm", "{0} ronnaohms", "Quantity.Unit.Electronic.Resistance.Ronnaohms"),
+        new (SI<Resistance>.Quetta, "{0} QΩ", "1 quettaohm", "{0} quettaohms", "Quantity.Unit.Electronic.Resistance.Quettaohms")
+    ];
 
     internal static IEnumerable<object[]> ResistanceShortNameArgs
     {
@@ -62,6 +74,15 @@ public class ResistanceTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for resistance units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<ResistanceUnitKeyTestData> ResistanceUnitKeyArgs =>
+        ResistanceTestDataTuples.Select(unitArgs => new ResistanceUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     [TestMethod]
     [DynamicData(nameof(ResistanceShortNameArgs))]
@@ -91,5 +112,17 @@ public class ResistanceTests
         var resultStr = resistance.FormatAs(resistanceUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Resistance unit will return the expected unit key.
+    /// </summary>
+    /// <param name="resistanceUnit">The resistance unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(ResistanceUnitKeyArgs))]
+    public void GetResistanceUnitKey_ValidUnit_ReturnsUnitKey(Unit<Resistance> resistanceUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, resistanceUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/VoltageTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/VoltageTests.cs
@@ -1,42 +1,54 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Electronic;
 
-using VoltageTestData = (Unit<Voltage> unit, string shortName, string longNameSingle, string longNamePlural);
+using VoltageTestData = QuantityTestData<Voltage>;
+using VoltageUnitKeyTestData = (Unit<Voltage> unit, string unitKey);
 
 [TestClass]
+[ExcludeFromCodeCoverage]
 public class VoltageTests
 {
-    internal static VoltageTestData[] VoltageTestDataTuples
-    {
-        get => new VoltageTestData[]
-        {
-            new (Voltage.Volt, "{0} V", "1 volt", "{0} volts"),
-            new (SI<Voltage>.Quecto, "{0} qV", "1 quectovolt", "{0} quectovolts"),
-            new (SI<Voltage>.Ronto, "{0} rV", "1 rontovolt", "{0} rontovolts"),
-            new (SI<Voltage>.Yocto, "{0} yV", "1 yoctovolt", "{0} yoctovolts"),
-            new (SI<Voltage>.Zepto, "{0} zV", "1 zeptovolt", "{0} zeptovolts"),
-            new (SI<Voltage>.Atto, "{0} aV", "1 attovolt", "{0} attovolts"),
-            new (SI<Voltage>.Femto, "{0} fV", "1 femtovolt", "{0} femtovolts"),
-            new (SI<Voltage>.Pico, "{0} pV", "1 picovolt", "{0} picovolts"),
-            new (SI<Voltage>.Nano, "{0} nV", "1 nanovolt", "{0} nanovolts"),
-            new (SI<Voltage>.Micro, "{0} µV", "1 microvolt", "{0} microvolts"),
-            new (SI<Voltage>.Milli, "{0} mV", "1 millivolt", "{0} millivolts"),
-            new (SI<Voltage>.Kilo, "{0} kV", "1 kilovolt", "{0} kilovolts"),
-            new (SI<Voltage>.Mega, "{0} MV", "1 megavolt", "{0} megavolts"),
-            new (SI<Voltage>.Giga, "{0} GV", "1 gigavolt", "{0} gigavolts"),
-            new (SI<Voltage>.Tera, "{0} TV", "1 teravolt", "{0} teravolts"),
-            new (SI<Voltage>.Peta, "{0} PV", "1 petavolt", "{0} petavolts"),
-            new (SI<Voltage>.Exa, "{0} EV", "1 exavolt", "{0} exavolts"),
-            new (SI<Voltage>.Zetta, "{0} ZV", "1 zettavolt", "{0} zettavolts"),
-            new (SI<Voltage>.Yotta, "{0} YV", "1 yottavolt", "{0} yottavolts"),
-            new (SI<Voltage>.Ronna, "{0} RV", "1 ronnavolt", "{0} ronnavolts"),
-            new (SI<Voltage>.Quetta, "{0} QV", "1 quettavolt", "{0} quettavolts")
-        };
-    }
+    /// <summary>
+    /// An array of test data tuples representing different voltage units and their display formats. Each
+    /// element in the array contains information about a voltage unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static VoltageTestData[] VoltageTestDataTuples =>
+    [
+        new (Voltage.Volt, "{0} V", "1 volt", "{0} volts", "Quantity.Unit.Electronic.Voltage.Volts"),
+        new (SI<Voltage>.Quecto, "{0} qV", "1 quectovolt", "{0} quectovolts", "Quantity.Unit.Electronic.Voltage.Quectovolts"),
+        new (SI<Voltage>.Ronto, "{0} rV", "1 rontovolt", "{0} rontovolts", "Quantity.Unit.Electronic.Voltage.Rontovolts"),
+        new (SI<Voltage>.Yocto, "{0} yV", "1 yoctovolt", "{0} yoctovolts", "Quantity.Unit.Electronic.Voltage.Yoctovolts"),
+        new (SI<Voltage>.Zepto, "{0} zV", "1 zeptovolt", "{0} zeptovolts", "Quantity.Unit.Electronic.Voltage.Zeptovolts"),
+        new (SI<Voltage>.Atto, "{0} aV", "1 attovolt", "{0} attovolts", "Quantity.Unit.Electronic.Voltage.Attovolts"),
+        new (SI<Voltage>.Femto, "{0} fV", "1 femtovolt", "{0} femtovolts", "Quantity.Unit.Electronic.Voltage.Femtovolts"),
+        new (SI<Voltage>.Pico, "{0} pV", "1 picovolt", "{0} picovolts", "Quantity.Unit.Electronic.Voltage.Picovolts"),
+        new (SI<Voltage>.Nano, "{0} nV", "1 nanovolt", "{0} nanovolts", "Quantity.Unit.Electronic.Voltage.Nanovolts"),
+        new (SI<Voltage>.Micro, "{0} µV", "1 microvolt", "{0} microvolts", "Quantity.Unit.Electronic.Voltage.Microvolts"),
+        new (SI<Voltage>.Centi, "{0} cV", "1 centivolt", "{0} centivolts", "Quantity.Unit.Electronic.Voltage.Centivolts"),
+        new (SI<Voltage>.Deci, "{0} dV", "1 decivolt", "{0} decivolts", "Quantity.Unit.Electronic.Voltage.Decivolts"),
+        new (SI<Voltage>.Deca, "{0} daV", "1 decavolt", "{0} decavolts", "Quantity.Unit.Electronic.Voltage.Decavolts"),
+        new (SI<Voltage>.Hecto, "{0} hV", "1 hectovolt", "{0} hectovolts", "Quantity.Unit.Electronic.Voltage.Hectovolts"),
+        new (SI<Voltage>.Milli, "{0} mV", "1 millivolt", "{0} millivolts", "Quantity.Unit.Electronic.Voltage.Millivolts"),
+        new (SI<Voltage>.Kilo, "{0} kV", "1 kilovolt", "{0} kilovolts", "Quantity.Unit.Electronic.Voltage.Kilovolts"),
+        new (SI<Voltage>.Mega, "{0} MV", "1 megavolt", "{0} megavolts", "Quantity.Unit.Electronic.Voltage.Megavolts"),
+        new (SI<Voltage>.Giga, "{0} GV", "1 gigavolt", "{0} gigavolts", "Quantity.Unit.Electronic.Voltage.Gigavolts"),
+        new (SI<Voltage>.Tera, "{0} TV", "1 teravolt", "{0} teravolts", "Quantity.Unit.Electronic.Voltage.Teravolts"),
+        new (SI<Voltage>.Peta, "{0} PV", "1 petavolt", "{0} petavolts", "Quantity.Unit.Electronic.Voltage.Petavolts"),
+        new (SI<Voltage>.Exa, "{0} EV", "1 exavolt", "{0} exavolts", "Quantity.Unit.Electronic.Voltage.Exavolts"),
+        new (SI<Voltage>.Zetta, "{0} ZV", "1 zettavolt", "{0} zettavolts", "Quantity.Unit.Electronic.Voltage.Zettavolts"),
+        new (SI<Voltage>.Yotta, "{0} YV", "1 yottavolt", "{0} yottavolts", "Quantity.Unit.Electronic.Voltage.Yottavolts"),
+        new (SI<Voltage>.Ronna, "{0} RV", "1 ronnavolt", "{0} ronnavolts", "Quantity.Unit.Electronic.Voltage.Ronnavolts"),
+        new (SI<Voltage>.Quetta, "{0} QV", "1 quettavolt", "{0} quettavolts", "Quantity.Unit.Electronic.Voltage.Quettavolts")
+    ];
 
     internal static IEnumerable<object[]> VoltageShortNameArgs
     {
@@ -62,6 +74,15 @@ public class VoltageTests
             }).ToArray()
         );
     }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for voltage units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    internal static IEnumerable<VoltageUnitKeyTestData> VoltageUnitKeyArgs =>
+        VoltageTestDataTuples.Select(unitArgs => new VoltageUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
 
     [TestMethod]
     [DynamicData(nameof(VoltageShortNameArgs))]
@@ -91,5 +112,17 @@ public class VoltageTests
         var resultStr = voltage.FormatAs(voltageUnit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from an Voltage unit will return the expected unit key.
+    /// </summary>
+    /// <param name="voltageUnit">The voltage unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(VoltageUnitKeyArgs))]
+    public void GetVoltageUnitKey_ValidUnit_ReturnsUnitKey(Unit<Voltage> voltageUnit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, voltageUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/QuantityTestData.cs
+++ b/Elements.Quantity.Tests/QuantityTestData.cs
@@ -1,0 +1,9 @@
+﻿namespace Elements.Quantity.Test;
+
+internal readonly record struct QuantityTestData<T>(
+    Unit<T> unit,
+    string shortName,
+    string longNameSingle,
+    string longNamePlural,
+    string unitKey
+) where T : unmanaged, IQuantity<T>;

--- a/Elements.Quantity/Core/Internal/StringExtension.cs
+++ b/Elements.Quantity/Core/Internal/StringExtension.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Elements.Quantity.Core.Internal
+{
+    internal static class StringExtension
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string ToPascalCase(this string str) =>
+            !string.IsNullOrEmpty(str) && !char.IsUpper(str[0])
+                ? $"{char.ToUpper(str[0])}{str.Substring(1)}"
+                : str;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Join(this IEnumerable<string> strings, string separator = "") => string.Join(separator, strings);
+    }
+}

--- a/Elements.Quantity/Core/QuantityHelper.cs
+++ b/Elements.Quantity/Core/QuantityHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Globalization;
 using System.Reflection;
+using System.Linq;
 
 namespace Elements.Quantity
 {
@@ -161,6 +162,12 @@ namespace Elements.Quantity
         {
             return unitCache[typeof(T)];
         }
+
+        public static IEnumerable<IUnit> GetAllUnits() =>
+            unitCache.Values.SelectMany(u => u);
+
+        public static IEnumerable<string> GetUnitKeys() =>
+            GetAllUnits().Select(u => u.UnitKey).OrderBy(k => k);
 
         public static Unit<T> SelectBestUnit<T>(this T q, List<UnitGroup> groups)
             where T : unmanaged, IQuantity<T>

--- a/Elements.Quantity/Core/QuantityInterfaces.cs
+++ b/Elements.Quantity/Core/QuantityInterfaces.cs
@@ -28,6 +28,15 @@ namespace Elements.Quantity
         Ratio Divide(T q);
 
         Unit<T> DefaultUnit { get; }
+
+        /// <summary>
+        /// The quantity family that this quantity type belongs to.
+        /// </summary>
+        /// <remarks>
+        /// This is used to generate the value for <see cref="Unit{T}.UnitKey"/>. For quantity
+        /// types that fall under the 'Basic' family, an empty string should always be returned.
+        /// </remarks>
+        string QuantityFamily { get; }
     }
 
     public interface IQuantitySI

--- a/Elements.Quantity/Core/Unit.cs
+++ b/Elements.Quantity/Core/Unit.cs
@@ -319,7 +319,7 @@ namespace Elements.Quantity
         {
             return unit.ConvertFrom(n);
         }
-    }
 
-    
+        public override string ToString() => UnitKey;
+    }
 }

--- a/Elements.Quantity/Core/UnitNonLinear.cs
+++ b/Elements.Quantity/Core/UnitNonLinear.cs
@@ -15,7 +15,8 @@ namespace Elements.Quantity
             Func<double, double> convertFromFunc,
             ICollection<UnitGroup> unitGroups,
             string[] shortNames,
-            string[] longNames) : base(0f, unitGroups, shortNames, longNames)
+            string[] longNames,
+            string? unitNameKeyOverride = null) : base(0f, unitGroups, shortNames, longNames, unitNameKeyOverride)
         {
             this.convertToFunc = convertToFunc;
             this.convertFromFunc = convertFromFunc;

--- a/Elements.Quantity/Quantities/Basic/Acceleration.cs
+++ b/Elements.Quantity/Quantities/Basic/Acceleration.cs
@@ -43,7 +43,7 @@ namespace Elements.Quantity
 
         public static readonly Unit<Acceleration> MetersPerSecondPerSecond = new Unit<Acceleration>(1,
             new UnitGroup[] { UnitGroup.Common, UnitGroup.Metric },
-            new string[] { " m/s^2", " m/s/s" }, new string[] { " meters per second per second", " meter per second per second", " meters per second squared", " meter per second squared" });
+            new string[] { " m/s^2", " m/s/s" }, new string[] { " meters per second squared", " meter per second squared", " meters per second per second", " meter per second per second" });
 
         #endregion
 

--- a/Elements.Quantity/Quantities/Basic/Acceleration.cs
+++ b/Elements.Quantity/Quantities/Basic/Acceleration.cs
@@ -39,6 +39,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Acceleration> DefaultUnit { get { return MetersPerSecondPerSecond; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
 
         public static readonly Unit<Acceleration> MetersPerSecondPerSecond = new Unit<Acceleration>(1,

--- a/Elements.Quantity/Quantities/Basic/Angle.cs
+++ b/Elements.Quantity/Quantities/Basic/Angle.cs
@@ -70,6 +70,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Angle> DefaultUnit { get { return Radian; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 

--- a/Elements.Quantity/Quantities/Basic/Density.cs
+++ b/Elements.Quantity/Quantities/Basic/Density.cs
@@ -28,6 +28,9 @@ namespace Elements.Quantity
 
         public Unit<Density> DefaultUnit { get { return KilogramPerCubicMeter; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Density> KilogramPerCubicMeter = new Unit<Density>(1,
             new UnitGroup[] { UnitGroup.Common },
             new string[] { " kg/m³", " kg/m^3" }, new string[] { " kilograms per cubic meter", " kilogram per cubic meter" });

--- a/Elements.Quantity/Quantities/Basic/Distance.cs
+++ b/Elements.Quantity/Quantities/Basic/Distance.cs
@@ -66,6 +66,9 @@ namespace Elements.Quantity
 
         public Unit<Distance> DefaultUnit { get { return Meter; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Distance> Meter = new UnitSI<Distance>(0, "", "");
 
         // Scientific

--- a/Elements.Quantity/Quantities/Basic/Luminance.cs
+++ b/Elements.Quantity/Quantities/Basic/Luminance.cs
@@ -28,6 +28,9 @@ namespace Elements.Quantity
 
         public Unit<Luminance> DefaultUnit { get { return CandelaPerSquareMeter; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Luminance> CandelaPerSquareMeter = new Unit<Luminance>(1,
             new UnitGroup[] { UnitGroup.Common },
             new string[] { " cd/m²", " cd/m^2" }, new string[] { " candelas per square meter", " candela per square meter" });

--- a/Elements.Quantity/Quantities/Basic/Mass.cs
+++ b/Elements.Quantity/Quantities/Basic/Mass.cs
@@ -71,6 +71,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Mass> DefaultUnit { get { return SI<Mass>.Kilo; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 

--- a/Elements.Quantity/Quantities/Basic/Pressure.cs
+++ b/Elements.Quantity/Quantities/Basic/Pressure.cs
@@ -77,6 +77,9 @@ namespace Elements.Quantity
 
         public Unit<Pressure> DefaultUnit { get { return Pascal; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Pressure> Pascal = new UnitSI<Pressure>(0, "", "");
         public static readonly Unit<Pressure> Bar = new Unit<Pressure>(1e5,
             new UnitGroup[] { UnitGroup.Common },

--- a/Elements.Quantity/Quantities/Basic/Ratio.cs
+++ b/Elements.Quantity/Quantities/Basic/Ratio.cs
@@ -39,6 +39,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Ratio> DefaultUnit { get { return RatioValue; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
 
         public static readonly Unit<Ratio> RatioValue = new Unit<Ratio>(1,

--- a/Elements.Quantity/Quantities/Basic/Temperature.cs
+++ b/Elements.Quantity/Quantities/Basic/Temperature.cs
@@ -39,6 +39,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Temperature> DefaultUnit { get { return Kelvin; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 
@@ -49,12 +52,14 @@ namespace Elements.Quantity
         public static readonly Unit<Temperature> Celsius = new UnitNonLinear<Temperature>(
             (K)=>(K-273.15), (C)=>(C+273.15),
             new UnitGroup[] { UnitGroup.Common },
-            new string[] { " °C" }, new string[] { " degrees Celsius", " degree Celsius", " Celsius" });
+            new string[] { " °C" }, new string[] { " degrees Celsius", " degree Celsius", " Celsius" },
+            "Celsius");
 
         public static readonly Unit<Temperature> Fahrenheit = new UnitNonLinear<Temperature>(
             (K) => (K * (9.0 / 5.0) - 459.67), (F) => ((F + 459.67)*(5.0 / 9.0)),
             new UnitGroup[] { UnitGroup.Common },
-            new string[] { " °F" }, new string[] { " degrees Fahrenheit", " degree Fahrenheit", " Fahrenheit" });
+            new string[] { " °F" }, new string[] { " degrees Fahrenheit", " degree Fahrenheit", " Fahrenheit" },
+            "Fahrenheit");
 
         #endregion
 

--- a/Elements.Quantity/Quantities/Basic/Time.cs
+++ b/Elements.Quantity/Quantities/Basic/Time.cs
@@ -39,6 +39,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Time> DefaultUnit { get { return Second; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Time> Millisecond = new Unit<Time>(1.0 / 1000.0,
             new UnitGroup[] { UnitGroup.Common },
             new string[] { " ms" }, new string[] { " milliseconds", " millisecond" });

--- a/Elements.Quantity/Quantities/Basic/Torque.cs
+++ b/Elements.Quantity/Quantities/Basic/Torque.cs
@@ -28,6 +28,9 @@ namespace Elements.Quantity
 
         public Unit<Torque> DefaultUnit { get { return NewtonMeter; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         public static readonly Unit<Torque> NewtonMeter = new Unit<Torque>(1,
             new UnitGroup[] { UnitGroup.Common },
             new string[] { " N m", " N·m" }, new string[] { " newton meters", " newton meter", " newton metres", " newton metre" });

--- a/Elements.Quantity/Quantities/Basic/Velocity.cs
+++ b/Elements.Quantity/Quantities/Basic/Velocity.cs
@@ -39,6 +39,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Velocity> DefaultUnit { get { return MetersPerSecond; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => string.Empty;
+
         // define actual units for the quantity (excluding SI units which are automatic)
 
         public static readonly Unit<Velocity> MetersPerSecond = new Unit<Velocity>(1,

--- a/Elements.Quantity/Quantities/Electronic/Current.cs
+++ b/Elements.Quantity/Quantities/Electronic/Current.cs
@@ -86,6 +86,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Current> DefaultUnit { get { return Ampere; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => "Electronic";
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 

--- a/Elements.Quantity/Quantities/Electronic/Resistance.cs
+++ b/Elements.Quantity/Quantities/Electronic/Resistance.cs
@@ -86,6 +86,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Resistance> DefaultUnit { get { return Ohm; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => "Electronic";
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 

--- a/Elements.Quantity/Quantities/Electronic/Voltage.cs
+++ b/Elements.Quantity/Quantities/Electronic/Voltage.cs
@@ -86,6 +86,9 @@ namespace Elements.Quantity
         // provide a default unit for the quantity - used when no explicit unit specified
         public Unit<Voltage> DefaultUnit { get { return Volt; } }
 
+        /// <inheritdoc/>
+        public string QuantityFamily => "Electronic";
+
         // define actual units for the quantity (excluding SI units which are automatic)
         // Parameters:
 


### PR DESCRIPTION
This PR aims to add a unique key for each unit. This will be useful for the upcoming custom formatter feature (PR #32) as well as to address the `UnitGroup` bug mentioned in #45 (PR #47).