### PR TITLE
fix: add missing ToString to newer quantity types

### DIFF
--- a/Elements.Quantity/Quantities/Basic/Density.cs
+++ b/Elements.Quantity/Quantities/Basic/Density.cs
@@ -70,5 +70,7 @@ namespace Elements.Quantity
         public static Density operator -(Density a) { return a.Multiply(-1); }
 
         #endregion
+
+        public override string ToString() => this.FormatAuto();
     }
 }

--- a/Elements.Quantity/Quantities/Basic/Luminance.cs
+++ b/Elements.Quantity/Quantities/Basic/Luminance.cs
@@ -66,5 +66,7 @@ namespace Elements.Quantity
         public static Luminance operator -(Luminance a) { return a.Multiply(-1); }
 
         #endregion
+
+        public override string ToString() => this.FormatAuto();
     }
 }

--- a/Elements.Quantity/Quantities/Basic/Torque.cs
+++ b/Elements.Quantity/Quantities/Basic/Torque.cs
@@ -66,5 +66,7 @@ namespace Elements.Quantity
         public static Torque operator -(Torque a) { return a.Multiply(-1); }
 
         #endregion
+
+        public override string ToString() => this.FormatAuto();
     }
 }


### PR DESCRIPTION
The `ToString` override for `Density`, `Luminance`, and `Torque` are currently missing, resulting in the full type name being returned instead. This PR aims to address this issue.

For known applications that utilize this library, these missing overrides are currently affecting the display node in Resonite for the mentioned quantity types.

Fixes #63 