### PR TITLE
fix(unitgroup): correct initialization for defined groups

### DIFF
--- a/Elements.Quantity.Tests/Core/UnitGroupTests.cs
+++ b/Elements.Quantity.Tests/Core/UnitGroupTests.cs
@@ -29,6 +29,16 @@ public class UnitGroupTests
     ];
 
     /// <summary>
+    /// Verifies that the default unit groups are available when being referenced.
+    /// </summary>
+    [TestMethod]
+    public void CheckDefaultUnitGroups_ProvidedCollectionMatches_ReturnsTrue()
+    {
+        var expectedDefaultUnitGroups = new UnitGroup[] { UnitGroup.Common };
+        CollectionAssert.AreEquivalent(expectedDefaultUnitGroups, UnitGroup.DefaultUnitGroups);
+    }
+
+    /// <summary>
     /// Verifies that the mockUnit mockGroup can register units.
     /// </summary>
     [TestMethod]

--- a/Elements.Quantity/Core/UnitGroup.cs
+++ b/Elements.Quantity/Core/UnitGroup.cs
@@ -10,13 +10,6 @@ namespace Elements.Quantity
     {
         #region UNIT_GROUPS
 
-        static UnitGroup()
-        {
-            DefaultUnitGroups.Add(Common);
-        }
-
-        public static List<UnitGroup> DefaultUnitGroups = new List<UnitGroup>();
-
         public static readonly UnitGroup Common = new UnitGroup();
         public static readonly UnitGroup Metric = new UnitGroup();
         public static readonly UnitGroup MetricThousands = new UnitGroup();
@@ -32,6 +25,8 @@ namespace Elements.Quantity
 
         public static readonly UnitGroup Imperial = new UnitGroup();
         public static readonly UnitGroup Surveying = new UnitGroup();
+
+        public static readonly List<UnitGroup> DefaultUnitGroups = [Common];
 
         private object _lock = new object();
 

--- a/Elements.Quantity/Core/UnitGroup.cs
+++ b/Elements.Quantity/Core/UnitGroup.cs
@@ -10,29 +10,29 @@ namespace Elements.Quantity
     {
         #region UNIT_GROUPS
 
-        public static readonly UnitGroup Common = new UnitGroup();
-        public static readonly UnitGroup Metric = new UnitGroup();
-        public static readonly UnitGroup MetricThousands = new UnitGroup();
-        public static readonly UnitGroup CommonMetric = new UnitGroup();
+        public static readonly UnitGroup Common = [];
+        public static readonly UnitGroup Metric = [];
+        public static readonly UnitGroup MetricThousands = [];
+        public static readonly UnitGroup CommonMetric = [];
 
-        public static readonly UnitGroup Scientific = new UnitGroup();
+        public static readonly UnitGroup Scientific = [];
 
-        public static readonly UnitGroup Astronomical = new UnitGroup();
-        public static readonly UnitGroup Molecular = new UnitGroup();
-        public static readonly UnitGroup Meteorological = new UnitGroup();
-        public static readonly UnitGroup Aviation = new UnitGroup();
-        public static readonly UnitGroup Maritime = new UnitGroup();
+        public static readonly UnitGroup Astronomical = [];
+        public static readonly UnitGroup Molecular = [];
+        public static readonly UnitGroup Meteorological = [];
+        public static readonly UnitGroup Aviation = [];
+        public static readonly UnitGroup Maritime = [];
 
-        public static readonly UnitGroup Imperial = new UnitGroup();
-        public static readonly UnitGroup Surveying = new UnitGroup();
+        public static readonly UnitGroup Imperial = [];
+        public static readonly UnitGroup Surveying = [];
 
         public static readonly List<UnitGroup> DefaultUnitGroups = [Common];
 
-        private object _lock = new object();
-
         #endregion
 
-        Dictionary<Type, SortedSet<IUnit>> units = new Dictionary<Type, SortedSet<IUnit>>();
+        private readonly object _lock = new();
+
+        private readonly Dictionary<Type, SortedSet<IUnit>> units = [];
 
         /// <inheritdoc/>
         public int Count => units.Sum(u => u.Value.Count);

--- a/Elements.Quantity/Core/UnitSI.cs
+++ b/Elements.Quantity/Core/UnitSI.cs
@@ -1,33 +1,27 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 
-namespace Elements.Quantity
+namespace Elements.Quantity;
+
+public class UnitSI<T> : Unit<T> where T : unmanaged, IQuantitySI<T>
 {
-    public class UnitSI<T> : Unit<T> where T : unmanaged, IQuantitySI<T>
+    private static readonly double SIPower = default(T).SIPower;
+
+    public UnitSI(int nFactor, string shortPrefix, string longPrefix) :
+        this(nFactor, [shortPrefix], [longPrefix])
     {
-        static UnitSI() { SIPower = default(T).SIPower; }
-        static double SIPower;
 
-        public UnitSI(int nFactor, string shortPrefix, string longPrefix) :
-            base(Math.Pow(Math.Pow(10, nFactor), SIPower),
-                new UnitGroup[] { UnitGroup.Metric },
-                new string[] { " " + shortPrefix + "{0}" },
-                new string[] { " " + longPrefix +  "{0}" })
-        {
-            if (nFactor % 3 == 0)
-                UnitGroup.MetricThousands.RegisterUnit(this);
-        }
-
-        public UnitSI(int nFactor, string[] shortPrefixes, string[] longPrefixes) :
-            base(Math.Pow(Math.Pow(10, nFactor), SIPower),
-                new UnitGroup[] { UnitGroup.Metric },
-                shortPrefixes.Select(p => " " + p + "{0}").ToArray(),
-                longPrefixes.Select(p => " " + p + "{0}").ToArray())
-        {
-            if (nFactor % 3 == 0)
-                UnitGroup.MetricThousands.RegisterUnit(this);
-        }
     }
 
+    public UnitSI(int nFactor, string[] shortPrefixes, string[] longPrefixes) :
+        base(Math.Pow(Math.Pow(10, nFactor), SIPower),
+            [UnitGroup.Metric],
+            [.. shortPrefixes.Select(p => $" {p}{{0}}")],
+            [.. longPrefixes.Select(p => $" {p}{{0}}")])
+    {
+        if (nFactor % 3 == 0)
+        {
+            UnitGroup.MetricThousands.RegisterUnit(this);
+        }
+    }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR is currently a draft since it is still being worked on.

This PR aims to fix the initialization issue with defined `UnitGroup` instances, mainly `Common`, `CommonMetric`, and `Metric` (and future ones as well) since these groups do not contain all applicable units unless a member from `QuantityHelper` is referenced before referencing said groups. More information can be found in #66.

Fixes #66 