### PR TITLE
feat(comparer): add IUnit comparers for equality and compare

### DIFF
--- a/Elements.Quantity.Tests/Core/QuantityHelperTests.cs
+++ b/Elements.Quantity.Tests/Core/QuantityHelperTests.cs
@@ -88,7 +88,7 @@ public partial class QuantityHelperTests
     public void GetAllUnits_UniqueUnits_ReturnsUniqueUnits()
     {
         var units = QuantityHelper.GetAllUnits();
-        var sortedSet = new SortedSet<IUnit>();
+        var sortedSet = new SortedSet<IUnit>(UnitComparer.Instance);
 
         foreach(var unit in units)
         {

--- a/Elements.Quantity.Tests/Core/UnitComparerTests.cs
+++ b/Elements.Quantity.Tests/Core/UnitComparerTests.cs
@@ -1,0 +1,144 @@
+﻿using Elements.Quantity.Test.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace Elements.Quantity.Test.Core;
+
+[TestClass]
+[ExcludeFromCodeCoverage]
+public sealed class UnitComparerTests
+{
+    private static readonly UnitComparer _comparer = UnitComparer.Instance;
+
+    /// <summary>
+    /// Verifies that <see cref="UnitComparer.Compare(IUnit?, IUnit?)"/> correctly returns 0
+    /// when both units are equal in value.
+    /// </summary>
+    [TestMethod]
+    public void Compare_UnitsAreEqual_ReturnsZero()
+    {
+        var mockUnitA = MockProvider.MockUnit;
+        Unit<MockQuantity> mockUnitB = new(MockProvider.MockUnitBaseRatio, null, MockProvider.MockUnitShortNames, MockProvider.MockUnitLongNames);
+
+        var actualResult = _comparer.Compare(mockUnitA, mockUnitB);
+        Assert.AreEqual(0, actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitComparer.Compare(IUnit?, IUnit?)"/> correctly returns 0
+    /// when both units are the same reference.
+    /// </summary>
+    [TestMethod]
+    public void Compare_UnitsAreSameReferences_ReturnsZero()
+    {
+        var actualResult = _comparer.Compare(MockProvider.MockUnit, MockProvider.MockUnit);
+        Assert.AreEqual(0, actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitComparer.Compare(IUnit?, IUnit?)"/> correctly returns the
+    /// expected value when one or both units are null.
+    /// </summary>
+    /// <param name="leftIsNull">Indicates whether the left unit is null.</param>
+    /// <param name="rightIsNull">Indicates whether the right unit is null.</param>
+    /// <param name="expectedResult">The expected result of the comparison.</param>
+    /// <param name="failureMessage">The message to display if the test fails.</param>
+    [TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Unfold)]
+    [DataRow(true, true, 0, "Two null params should return 0.")]
+    [DataRow(true, false, -1, "A null left param and non-null right param should return -1.")]
+    [DataRow(false, true, 1, "A non-null left param and null right param should return 1.")]
+    public void Compare_NullParams_ReturnsExpectedResult(bool leftIsNull, bool rightIsNull, int expectedResult, string failureMessage)
+    {
+        IUnit? left = leftIsNull ? null : MockProvider.MockUnit;
+        IUnit? right = rightIsNull ? null : MockProvider.MockUnit;
+
+        var actualResult = _comparer.Compare(left, right);
+        Assert.AreEqual(expectedResult, actualResult, failureMessage);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitComparer.Compare(IUnit?, IUnit?)"/> correctly sorts a list
+    /// of units in ascending order based on <see cref="IUnit.UnitKey"/> first then by <see cref="IUnit.Ratio"/>.
+    /// </summary>
+    [TestMethod]
+    public void SortWithComparer_DifferntUnitImplementations_SortsCorrectly()
+    {
+        LeastUnit leastUnit = new();
+        GreatUnit greatUnit = new();
+        IUnit otherUnit = new Unit<MockQuantity>(MockProvider.MockUnitBaseRatio, [], ["x"], [$"{MockProvider.MockUnitLongNames[0]}xxx"]);
+
+        IUnit[] expectedResult =
+        [
+            leastUnit,
+            MockProvider.MockUnit,
+            otherUnit,
+            greatUnit
+        ];
+
+        IUnit[] units =
+        [
+            otherUnit,
+            MockProvider.MockUnit,
+            greatUnit,
+            leastUnit
+        ];
+        units.Sort(_comparer);
+
+        CollectionAssert.AreEqual(expectedResult, units);
+    }
+}
+
+/// <summary>
+/// A mock implementation of the <see cref="IUnit"/> interface for testing purposes. <see cref="UnitKey"/>
+/// and <see cref="CompareTo(IUnit?)"/> methods are overridden to provide a unique implementation that should
+/// be ignored by the comparer. This unit should always be sorted to the beggining of the list.
+/// </summary>
+file sealed class LeastUnit : IUnit
+{
+    public double Ratio => long.MinValue;
+
+    public Type ValueType => throw new NotImplementedException();
+
+    public string DefaultShortUnitName => throw new NotImplementedException();
+
+    public string DefaultLongUnitNamePluralForm => throw new NotImplementedException();
+
+    public string DefaultLongUnitNameSingularForm => throw new NotImplementedException();
+
+    public string UnitKey => "AAAA";
+
+    public int CompareTo(IUnit? other) => 1;
+
+    public ICollection<string> GetUnitNames() => throw new NotImplementedException();
+
+    public override string ToString() => "LeastUnit";
+}
+
+/// <summary>
+/// A mock implementation of the <see cref="IUnit"/> interface for testing purposes. <see cref="UnitKey"/>
+/// and <see cref="CompareTo(IUnit?)"/> methods are overridden to provide a unique implementation that should
+/// be ignored by the comparer. This unit should always be sorted to the end of the list.
+/// </summary>
+file sealed class GreatUnit : IUnit
+{
+    public double Ratio => long.MaxValue;
+
+    public Type ValueType => throw new NotImplementedException();
+
+    public string DefaultShortUnitName => throw new NotImplementedException();
+
+    public string DefaultLongUnitNamePluralForm => throw new NotImplementedException();
+
+    public string DefaultLongUnitNameSingularForm => throw new NotImplementedException();
+
+    public string UnitKey => "ZZZZZ";
+
+    public int CompareTo(IUnit? other) => -1;
+
+    public ICollection<string> GetUnitNames() => throw new NotImplementedException();
+
+    public override string ToString() => "GreatUnit";
+}

--- a/Elements.Quantity.Tests/Core/UnitEqualityComparerTests.cs
+++ b/Elements.Quantity.Tests/Core/UnitEqualityComparerTests.cs
@@ -1,0 +1,120 @@
+﻿using Elements.Quantity.Test.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Elements.Quantity.Test.Core;
+
+[TestClass]
+[ExcludeFromCodeCoverage]
+public sealed class UnitEqualityComparerTests
+{
+    private static readonly UnitEqualityComparer _comparer = UnitEqualityComparer.Instance;
+
+    private static IEnumerable<IUnit> _differntUnitTypes =>
+    [
+        MockProvider.MockUnit,
+        new MockUnit()
+    ];
+
+    /// <summary>
+    /// Verifies that <see cref="UnitEqualityComparer.Equals(IUnit?, IUnit?)"/> correctly determines equality when
+    /// both units are different references but have equal properties.
+    /// </summary>
+    [TestMethod]
+    public void CompareEquality_UnitsAreEqual_ReturnsTrue()
+    {
+        var mockUnitA = MockProvider.MockUnit;
+        Unit<MockQuantity> mockUnitB = new(mockUnitA.Ratio, [], MockProvider.MockUnitShortNames, MockProvider.MockUnitLongNames);
+
+        var actualResult = _comparer.Equals(mockUnitA, mockUnitB);
+        Assert.IsTrue(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitEqualityComparer.Equals(IUnit?, IUnit?)"/> correctly determines equality when
+    /// both units are the same reference.
+    /// </summary>
+    [TestMethod]
+    public void CompareEquality_UnitsAreSameReferences_ReturnsTrue()
+    {
+        var actualResult = _comparer.Equals(MockProvider.MockUnit, MockProvider.MockUnit);
+        Assert.IsTrue(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitEqualityComparer.Equals(IUnit?, IUnit?)"/> correctly determines equality when
+    /// both units are null.
+    /// </summary>
+    /// <param name="leftIsNull">Indicates whether the left unit is null.</param>
+    /// <param name="rightIsNull">Indicates whether the right unit is null.</param>
+    /// <param name="expectedResult">The expected result of the equality comparison.</param>
+    /// <param name="failureMessage">The message to display if the test fails.</param>
+    [TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Unfold)]
+    [DataRow(true, true, true, "Two null params should be considered equal.")]
+    [DataRow(true, false, false, "A null left param and non-null right param cannot be considered equal.")]
+    [DataRow(false, true, false, "A non-null left param and null right param cannot be considered equal.")]
+    public void CompareEquality_NullParams_ReturnsExpectedResult(bool leftIsNull, bool rightIsNull, bool expectedResult, string failureMessage)
+    {
+        IUnit? left = leftIsNull ? null : MockProvider.MockUnit;
+        IUnit? right = rightIsNull ? null : MockProvider.MockUnit;
+        var actualResult = _comparer.Equals(left, right);
+        Assert.AreEqual(expectedResult, actualResult, failureMessage);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitEqualityComparer.Equals(IUnit?, IUnit?)"/> correctly determines inequality.
+    /// </summary>
+    [TestMethod]
+    public void CompareEquality_UnitsAreDifferent_ReturnsFalse()
+    {
+        var mockUnitA = MockProvider.MockUnit;
+        Unit<MockQuantity> mockUnitB = new(3.0, null, ["m2"], ["mock2"]);
+        var actualResult = _comparer.Equals(mockUnitA, mockUnitB);
+        Assert.IsFalse(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitEqualityComparer.GetHashCode(IUnit)"/> returns the same hash code as the one from
+    /// <see cref="IUnit.UnitKey"/>.
+    /// </summary>
+    /// <param name="unit">The unit to get the hash code for.</param>
+    [TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Unfold)]
+    [DynamicData(nameof(_differntUnitTypes))]
+    public void GetHashCode_SameUnits_ReturnsSameHashCodeValue(IUnit unit)
+    {
+        var expectedHashCode = HashCode.Combine(unit.UnitKey, unit.Ratio);
+        var actualHashCode = _comparer.GetHashCode(unit);
+
+        Assert.AreEqual(expectedHashCode, actualHashCode);
+    }
+}
+
+/// <summary>
+/// A mock implementation of the <see cref="IUnit"/> interface for testing purposes. <see cref="UnitKey"/>
+/// and <see cref="GetHashCode()"/> methods are overridden to provide a unique implementation that should
+/// be ignored by the comparer.
+/// </summary>
+file sealed class MockUnit : IUnit
+{
+    public double Ratio => 2.0d;
+
+    public Type ValueType => throw new NotImplementedException();
+
+    public string DefaultShortUnitName => throw new NotImplementedException();
+
+    public string DefaultLongUnitNamePluralForm => throw new NotImplementedException();
+
+    public string DefaultLongUnitNameSingularForm => throw new NotImplementedException();
+
+    public string UnitKey => "MockUnitKey";
+
+    public int CompareTo(IUnit? other) => throw new NotImplementedException();
+
+    public ICollection<string> GetUnitNames() => throw new NotImplementedException();
+
+    public override int GetHashCode() => UnitKey.GetHashCode() + 1;
+
+    public override string ToString() => "MockUnit";
+}

--- a/Elements.Quantity.Tests/Core/UnitGroupTests.cs
+++ b/Elements.Quantity.Tests/Core/UnitGroupTests.cs
@@ -223,8 +223,11 @@ public class UnitGroupTests
         mockGroup.RegisterUnit(Velocity.MetersPerSecond);
         mockGroup.RegisterUnit(MockProvider.MockUnit);
         mockGroup.RegisterUnit(Density.GramPerCubicCentimeter);
+        mockGroup.RegisterUnit(Pressure.Millibar);
         mockGroup.RegisterUnit(Velocity.Knots);
+        mockGroup.RegisterUnit(Pressure.Bar);
         mockGroup.RegisterUnit(Density.KilogramPerCubicMeter);
+        mockGroup.RegisterUnit(SI<Pressure>.Hecto);
 
         var expectedOrder = new IUnit[]
         {
@@ -233,7 +236,10 @@ public class UnitGroupTests
             Velocity.MetersPerSecond,
             MockProvider.MockUnit,
             Density.KilogramPerCubicMeter,
-            Density.GramPerCubicCentimeter
+            Density.GramPerCubicCentimeter,
+            SI<Pressure>.Hecto,
+            Pressure.Millibar,
+            Pressure.Bar
         };
 
         var actualOrder = new List<IUnit>();

--- a/Elements.Quantity.Tests/Core/UnitTests.cs
+++ b/Elements.Quantity.Tests/Core/UnitTests.cs
@@ -32,4 +32,195 @@ public class UnitTests
         var formattedValue = unit.FormatAs(quantity, formatNum);
         Assert.AreEqual(expectedValue, formattedValue);
     }
+
+    /// <summary>
+    /// Verifies that <see cref="Unit{T}.Equals(Unit{T})"/> returns true when two units have equal values.
+    /// </summary>
+    [TestMethod]
+    public void TypedEquals_ObjectsHaveEqualValues_ReturnsTrue()
+    {
+        var mockUnitB = new Unit<MockQuantity>(MockProvider.MockUnitBaseRatio, null, MockProvider.MockUnitShortNames, MockProvider.MockUnitLongNames);
+
+        var actualResult = MockProvider.MockUnit.Equals(mockUnitB);
+        Assert.IsTrue(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Unit{T}.Equals(Unit{T})"/> returns false when two units have different values.
+    /// </summary>
+    [TestMethod]
+    public void TypedEquals_ObjectsHaveDifferentValues_ReturnsFalse()
+    {
+        var mockUnitB = new Unit<MockQuantity>(3.0, null, ["M2"], ["MockTwo"]);
+
+        var actualResult = MockProvider.MockUnit.Equals(mockUnitB);
+        Assert.IsFalse(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Unit{T}.Equals(Unit{T})"/> returns false when the other unit is null.
+    /// </summary>
+    [TestMethod]
+    public void TypedEquals_OtherObjectIsNull_ReturnsFalse()
+    {
+        IUnit? mockUnitB = null;
+
+        var actualResult = MockProvider.MockUnit.Equals(mockUnitB);
+        Assert.IsFalse(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Unit{T}.Equals(object)"/> returns true when two objects have equal values.
+    /// </summary>
+    [TestMethod]
+    public void ObjectEquals_ObjectHasEqualValues_ReturnsTrue()
+    {
+        object otherObject = new Unit<MockQuantity>(MockProvider.MockUnitBaseRatio, null, MockProvider.MockUnitShortNames, MockProvider.MockUnitLongNames);
+
+        var actualResult = MockProvider.MockUnit.Equals(otherObject);
+        Assert.IsTrue(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Unit{T}.Equals(object)"/> returns false when two objects have different values.
+    /// </summary>
+    [TestMethod]
+    public void ObjectEquals_ObjectHasDifferentValues_ReturnsFalse()
+    {
+        object otherObject = new Unit<MockQuantity>(3.0, null, ["M2"], ["MockTwo"]);
+
+        var actualResult = MockProvider.MockUnit.Equals(otherObject);
+        Assert.IsFalse(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Unit{T}.Equals(object)"/> returns false when the other object is null.
+    /// </summary>
+    [TestMethod]
+    public void ObjectEquals_ObjectIsNull_ReturnsFalse()
+    {
+        object? otherObject = null;
+
+        var actualResult = MockProvider.MockUnit.Equals(otherObject);
+        Assert.IsFalse(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Unit{T}.Equals(object)"/> returns false when the other object is a different type.
+    /// </summary>
+    [TestMethod]
+    public void ObjectEquals_ObjectIsDifferentType_ReturnsFalse()
+    {
+        var otherObject = new object();
+
+        var actualResult = MockProvider.MockUnit.Equals(otherObject);
+        Assert.IsFalse(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that the equality operator (==) returns true when two units have equal values.
+    /// </summary>
+    [TestMethod]
+    public void EqualityOperator_OperandsHaveEqualValues_ReturnsTrue()
+    {
+        var mockUnitA = MockProvider.MockUnit;
+        var mockUnitB = new Unit<MockQuantity>(MockProvider.MockUnitBaseRatio, null, MockProvider.MockUnitShortNames, MockProvider.MockUnitLongNames);
+
+        var actualResult = mockUnitA == mockUnitB;
+        Assert.IsTrue(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that the equality operator (==) returns false when two units have different values.
+    /// </summary>
+    [TestMethod]
+    public void EqualityOperator_OperandsHaveDifferentValues_ReturnsFalse()
+    {
+        var mockUnitA = MockProvider.MockUnit;
+        var mockUnitB = new Unit<MockQuantity>(3.0, null, ["M2"], ["MockTwo"]);
+
+        var actualResult = mockUnitA == mockUnitB;
+        Assert.IsFalse(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that the equality operator (==) returns the expected value when one or both operands are null.
+    /// </summary>
+    /// <param name="leftIsNull">Indicates whether the left operand is null.</param>
+    /// <param name="rightIsNull">Indicates whether the right operand is null.</param>
+    /// <param name="expectedResult">The expected result of the equality comparison.</param>
+    /// <param name="failureMessage">The message to display if the test fails.</param>
+    [TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Unfold)]
+    [DataRow(true, true, true, "Two null operands should be considered equal.")]
+    [DataRow(true, false, false, "A null left operand and non-null right operand cannot be considered equal.")]
+    [DataRow(false, true, false, "A non-null left operand and null right operand cannot be considered equal.")]
+    public void EqualityOperator_NullOperands_ReturnsExpectedResult(bool leftIsNull, bool rightIsNull, bool expectedResult, string failureMessage)
+    {
+        Unit<MockQuantity>? left = leftIsNull ? null : MockProvider.MockUnit;
+        Unit<MockQuantity>? right = rightIsNull ? null : MockProvider.MockUnit;
+
+        var actualResult = left == right;
+        Assert.AreEqual(expectedResult, actualResult, failureMessage);
+    }
+
+    /// <summary>
+    /// Verifies that the inequality operator (!=) returns false when two units have equal values.
+    /// </summary>
+    [TestMethod]
+    public void InequalityOperator_OperandsHaveEqualValues_ReturnsFalse()
+    {
+        var mockUnitA = MockProvider.MockUnit;
+        var mockUnitB = new Unit<MockQuantity>(MockProvider.MockUnitBaseRatio, null, MockProvider.MockUnitShortNames, MockProvider.MockUnitLongNames);
+
+        var actualResult = mockUnitA != mockUnitB;
+        Assert.IsFalse(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that the inequality operator (!=) returns true when two units have different values.
+    /// </summary>
+    [TestMethod]
+    public void InequalityOperator_OperandsHaveDifferentValues_ReturnsTrue()
+    {
+        var mockUnitA = MockProvider.MockUnit;
+        var mockUnitB = new Unit<MockQuantity>(3.0, null, ["M2"], ["MockTwo"]);
+
+        var actualResult = mockUnitA != mockUnitB;
+        Assert.IsTrue(actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that the inequality operator (!=) returns the expected value when one or both operands are null.
+    /// </summary>
+    /// <param name="leftIsNull">Indicates whether the left operand is null.</param>
+    /// <param name="rightIsNull">Indicates whether the right operand is null.</param>
+    /// <param name="expectedResult">The expected result of the inequality comparison.</param>
+    /// <param name="failureMessage">The message to display if the test fails.</param>
+    [TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Unfold)]
+    [DataRow(true, true, false, "Two null operands cannot be considered unequal.")]
+    [DataRow(true, false, true, "A null left operand and non-null right operand should be considered unequal.")]
+    [DataRow(false, true, true, "A non-null left operand and null right operand should be considered unequal.")]
+    public void InequalityOperator_NullOperands_ReturnsExpectedResult(bool leftIsNull, bool rightIsNull, bool expectedResult, string failureMessage)
+    {
+        Unit<MockQuantity>? left = leftIsNull ? null : MockProvider.MockUnit;
+        Unit<MockQuantity>? right = rightIsNull ? null : MockProvider.MockUnit;
+
+        var actualResult = left != right;
+        Assert.AreEqual(expectedResult, actualResult, failureMessage);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Unit{T}.GetHashCode()"/> returns the expected hash code based on <see cref="Unit{T}.UnitKey"/>
+    /// and <see cref="Unit{T}.Ratio"/>.
+    /// </summary>
+    [TestMethod]
+    public void GetHashCode_Call_ReturnsExpectedHashCode()
+    {
+        var mockUnit = MockProvider.MockUnit;
+
+        var expectedResult = HashCode.Combine(mockUnit.UnitKey, mockUnit.Ratio);
+        var actualResult = mockUnit.GetHashCode();
+
+        Assert.AreEqual(expectedResult, actualResult);
+    }
 }

--- a/Elements.Quantity.Tests/Core/UnitTests.cs
+++ b/Elements.Quantity.Tests/Core/UnitTests.cs
@@ -17,7 +17,7 @@ public class UnitTests
         .Select(argsData => new [] { argsData.formatNum, argsData.expectedValue });
 
     /// <summary>
-    /// Tests that the <see cref="Unit{T}.FormatAs(T, string, bool, string)"/> method correctly formats a
+    /// Verifies that the <see cref="Unit{T}.FormatAs(T, string, bool, string)"/> method correctly formats a
     /// unit's value using the specified string format.
     /// </summary>
     /// <param name="formatNum">The string format to apply to the unit's value.</param>
@@ -26,11 +26,67 @@ public class UnitTests
     [DynamicData(nameof(ValueFormatArgs))]
     public void UnitFormatAs_ProvidedStringFormatIsValid_FormatsUnitNumberInFormat(string formatNum, string expectedValue)
     {
-        var unit = MockProvider.MockUnit;
-        var quantity = new MockQuantity(unit.Ratio);
+        var quantity = new MockQuantity(MockProvider.MockUnitBaseRatio);
 
-        var formattedValue = unit.FormatAs(quantity, formatNum);
+        var formattedValue = MockProvider.MockUnit.FormatAs(quantity, formatNum);
         Assert.AreEqual(expectedValue, formattedValue);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitComparer.Compare(IUnit?, IUnit?)"/> correctly returns 0
+    /// when the given unit has the same values as the other unit.
+    /// </summary>
+    [TestMethod]
+    public void CompareTo_UnitHasSameValues_ReturnsZero()
+    {
+        Unit<MockQuantity> mockUnitB = new(MockProvider.MockUnitBaseRatio, null, MockProvider.MockUnitShortNames, MockProvider.MockUnitLongNames);
+
+        var actualResult = MockProvider.MockUnit.CompareTo(mockUnitB);
+        Assert.AreEqual(0, actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitComparer.Compare(IUnit?, IUnit?)"/> correctly returns the
+    /// expected value when the given unit has a greater value or a lesser value than the other
+    /// unit.
+    /// </summary>
+    /// <param name="ratio">The ratio of the unit to compare to.</param>
+    /// <param name="unitKeyOverride">The key override of the unit to compare to.</param>
+    /// <param name="expectedValue">The expected comparison result.</param>
+    /// <param name="failureMessage">The message to display if the test fails.</param>
+    [TestMethod]
+    [DataRow(MockProvider.MockUnitBaseRatio + 1, null, -1, "A value of -1 should be returned due to the unit having a higher ratio.")]
+    [DataRow(MockProvider.MockUnitBaseRatio - 1, null, 1, "A value of 1 should be returned due to the unit having a lower ratio.")]
+    [DataRow(MockProvider.MockUnitBaseRatio, $"a{MockProvider.MockUnitNameKeyOverride}", 1, "A value of 1 should be returned due to the unit having a key that comes first alphabetically.")]
+    [DataRow(MockProvider.MockUnitBaseRatio, $"z{MockProvider.MockUnitNameKeyOverride}", -1, "A value of -1 should be returned due to the unit having a key that comes last alphabetically.")]
+    public void CompareTo_UnitHasDifferentValues_ReturnsExpectedValue(double ratio, string? unitKeyOverride, int expectedValue, string failureMessage)
+    {
+        var mockUnitB = new Unit<MockQuantity>(ratio, null, MockProvider.MockUnitShortNames, MockProvider.MockUnitLongNames, unitKeyOverride);
+
+        var actualResult = MockProvider.MockUnit.CompareTo(mockUnitB);
+        Assert.AreEqual(expectedValue, actualResult, failureMessage);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitComparer.Compare(IUnit?, IUnit?)"/> correctly returns 0
+    /// when both units are the same reference.
+    /// </summary>
+    [TestMethod]
+    public void CompareTo_UnitIsSameReference_ReturnsZero()
+    {
+        var actualResult = MockProvider.MockUnit.CompareTo(MockProvider.MockUnit);
+        Assert.AreEqual(0, actualResult);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnitComparer.Compare(IUnit?, IUnit?)"/> correctly returns 1
+    /// when the given unit is null.
+    /// </summary>
+    [TestMethod]
+    public void CompareTo_NullUnit_ReturnsOne()
+    {
+        var actualResult = MockProvider.MockUnit.CompareTo(null);
+        Assert.AreEqual(1, actualResult);
     }
 
     /// <summary>

--- a/Elements.Quantity.Tests/MockProvider.cs
+++ b/Elements.Quantity.Tests/MockProvider.cs
@@ -9,6 +9,14 @@ namespace Elements.Quantity.Test;
 
 internal static class MockProvider
 {
+    internal const double MockUnitBaseRatio = 1.0;
+
+    internal static readonly string[] MockUnitShortNames = [" u"];
+
+    internal static readonly string[] MockUnitLongNames = [" units", " unit"];
+
+    internal const string MockUnitNameKeyOverride = "MockUnitNameKeyOverride";
+
     internal static readonly Unit<MockQuantity> MockUnit =
-        new (1, null, [" u"], [" units", " unit"]);
+        new (MockUnitBaseRatio, null, MockUnitShortNames, MockUnitLongNames);
 }

--- a/Elements.Quantity.Tests/Mocks/MockQuantity.cs
+++ b/Elements.Quantity.Tests/Mocks/MockQuantity.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace Elements.Quantity.Test.Mocks
 {
     [ExcludeFromCodeCoverage]
-    internal readonly struct MockQuantity : IQuantity<MockQuantity>
+    public readonly struct MockQuantity : IQuantity<MockQuantity>
     {
         public readonly double BaseValue;
         double IQuantity.BaseValue => BaseValue;

--- a/Elements.Quantity/Core/QuantityHelper.cs
+++ b/Elements.Quantity/Core/QuantityHelper.cs
@@ -292,7 +292,7 @@ namespace Elements.Quantity
                                     units.Add(unit);
                             }
 
-                    units.Sort();
+                    units.Sort(UnitComparer.Instance);
 
                     // generate name cache
                     var names = new Dictionary<string, IUnit>();

--- a/Elements.Quantity/Core/Unit.cs
+++ b/Elements.Quantity/Core/Unit.cs
@@ -23,7 +23,7 @@ namespace Elements.Quantity
         ICollection<string> GetUnitNames();
     }
 
-    public class Unit<T> : IUnit where T : unmanaged, IQuantity<T>
+    public class Unit<T> : IUnit, IEquatable<Unit<T>> where T : unmanaged, IQuantity<T>
     {
         private const byte DEFAULT_SHORT_UNIT_NAME_INDEX = 0;
         private const byte DEFAULT_LONG_UNIT_NAME_PLURAL_FORM_INDEX = 0;
@@ -329,20 +329,16 @@ namespace Elements.Quantity
             return unit.ConvertFrom(n);
         }
 
+        public override bool Equals(object? obj) => obj is Unit<T> unit && Equals(unit);
+
+        public bool Equals(Unit<T>? other) => other is not null && UnitKey == other.UnitKey && Ratio == other.Ratio;
+
+        public override int GetHashCode() => HashCode.Combine(UnitKey, Ratio);
+
+        public static bool operator ==(Unit<T>? a, Unit<T>? b) => a is null ? b is null : a.Equals(b);
+
+        public static bool operator !=(Unit<T>? a, Unit<T>? b) => !(a == b);
+
         public override string ToString() => UnitKey;
-
-        public override bool Equals(object? obj)
-        {
-            if (obj == null || obj is not Unit<T>)
-            {
-                return false;
-            }
-
-            var otherUnit = (Unit<T>)obj;
-
-            return otherUnit.UnitKey == UnitKey;
-        }
-
-        public override int GetHashCode() => UnitKey.GetHashCode();
     }
 }

--- a/Elements.Quantity/Core/Unit.cs
+++ b/Elements.Quantity/Core/Unit.cs
@@ -42,9 +42,25 @@ namespace Elements.Quantity
 
         public Type ValueType => typeof(T);
 
+        /// <summary>
+        /// Performs a comparison of this and an <see cref="IUnit"/> instance that returns a
+        /// value indicating whether one instance is less than, equal to, or greater than the
+        /// other.
+        /// </summary>
+        /// <param name="other">The other <see cref="IUnit"/> instance to compare to.</param>
+        /// <returns>
+        /// A signed integer that indicates the relative values of this and <paramref name="other"/>,
+        /// as shown in the following list.
+        /// <list type="bullet">
+        ///   <item><b>Value</b> - Meaning</item>
+        ///   <item><b>Less than zero</b> - this is less than <paramref name="other"/>.</item>
+        ///   <item><b>Zero</b> - this equals <paramref name="other"/>.</item>
+        ///   <item><b>Greater than zero</b> - this is greater than <paramref name="other"/>.</item>
+        /// </list>
+        /// </returns>
         public int CompareTo(IUnit? other)
         {
-            if (other == null)
+            if (other is null)
             {
                 return 1;
             }

--- a/Elements.Quantity/Core/UnitComparer.cs
+++ b/Elements.Quantity/Core/UnitComparer.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+
+namespace Elements.Quantity;
+
+/// <summary>
+/// A comparer for <see cref="IUnit"/> instances.
+/// </summary>
+/// <remarks>
+/// Since the comparer is expecting <see cref="IUnit"/> as parameters, it must implement
+/// its own comparison logic without calling the object's <c>CompareTo</c> method, which
+/// is not guaranteed to follow the same logic between different implementations of
+/// <see cref="IUnit"/>.
+/// </remarks>
+public sealed class UnitComparer : Comparer<IUnit>
+{
+    /// <summary>
+    /// A singleton instance of the <see cref="UnitEqualityComparer"/> class.
+    /// </summary>
+    public static readonly UnitComparer Instance = new();
+
+    /// <summary>
+    /// Performs a comparison of two <see cref="IUnit"/> instances and returns a
+    /// value indicating whether one instance is less than, equal to, or greater
+    /// than the other.
+    /// </summary>
+    /// <remarks>
+    /// The comparer should always determine the return value if one or both
+    /// parameters are null. Otherwise, 
+    /// </remarks>
+    /// <inheritdoc/>
+    public override int Compare(IUnit? x, IUnit? y) =>
+        (x, y) switch
+        {
+            (null, null) => 0,
+            (null, _) => -1,
+            (_, null) => 1,
+            _ => CompareInternal(x, y)
+        };
+
+    /// <summary>
+    /// Performs a comparison of two <see cref="IUnit"/> instances internally and
+    /// returns a value indicating whether one instance is less than, equal to, or
+    /// greater than the other.
+    /// </summary>
+    /// <remarks>
+    /// The ratio of the two units is compared first. If the ratios are equal, then
+    /// the unit keys are compared.
+    /// </remarks>
+    /// <returns>
+    /// A signed integer that indicates the relative values of <paramref name="x"/> and <paramref name="y"/>,
+    /// as shown in the following list.
+    /// <list type="bullet">
+    ///   <item><b>Value</b> - Meaning</item>
+    ///   <item><b>Less than zero</b> - <paramref name="x"/> is less than <paramref name="y"/>.</item>
+    ///   <item><b>Zero</b> - <paramref name="x"/> equals <paramref name="y"/>.</item>
+    ///   <item><b>Greater than zero</b> - <paramref name="x"/> is greater than <paramref name="y"/>.</item>
+    /// </list>
+    /// </returns>
+    private static int CompareInternal(IUnit x, IUnit y)
+    {
+        var ratioCompareResult = x.Ratio.CompareTo(y.Ratio);
+        return ratioCompareResult != 0 ? ratioCompareResult : x.UnitKey.CompareTo(y.UnitKey);
+    }
+}

--- a/Elements.Quantity/Core/UnitEqualityComparer.cs
+++ b/Elements.Quantity/Core/UnitEqualityComparer.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Elements.Quantity;
+
+/// <summary>
+/// An equality comparer for <see cref="IUnit"/> instances.
+/// </summary>
+/// <remarks>
+/// Since the comparer is expecting <see cref="IUnit"/> as parameters, it must implement
+/// its own equality comparison logic without calling the object's <c>Equals</c> and
+/// <c>GetHashCode</c> methods, which is not guaranteed to follow the same logic between
+/// different implementations of <see cref="IUnit"/>.
+/// </remarks>
+public sealed class UnitEqualityComparer : EqualityComparer<IUnit>
+{
+    /// <summary>
+    /// A singleton instance of the <see cref="UnitEqualityComparer"/> class.
+    /// </summary>
+    public static readonly UnitEqualityComparer Instance = new();
+
+    /// <summary>
+    /// Determines whether two objects of type <see cref="IUnit"/> are equal.
+    /// </summary>
+    /// <inheritdoc/>
+    public override bool Equals(IUnit? x, IUnit? y) =>
+        x is null ? y is null : x.UnitKey == y?.UnitKey && x.Ratio == y!.Ratio;
+
+    /// <summary>
+    /// Serves as a hash function for the specified <see cref="IUnit"/> for hashing
+    /// algorithms and data structures, such as a hash table.
+    /// </summary>
+    /// <remarks>
+    /// Although the parameter can be changed to be nullable, the base class <see cref="EqualityComparer{T}"/>
+    /// requires it to not be null. Therefore, <see cref="DisallowNullAttribute"/> is left on here.
+    /// </remarks>
+    /// <inheritdoc/>
+    public override int GetHashCode([DisallowNull]IUnit unit) => HashCode.Combine(unit.UnitKey, unit.Ratio);
+}

--- a/Elements.Quantity/Core/UnitGroup.cs
+++ b/Elements.Quantity/Core/UnitGroup.cs
@@ -116,7 +116,7 @@ namespace Elements.Quantity
                 return set;
             }
 
-            set = [];
+            set = new SortedSet<IUnit>(UnitComparer.Instance);
             units.Add(type, set);
             return set;
         }


### PR DESCRIPTION
When creating the PR for #67, I was required to create an equality comparer for `IUnit` in order to utilize the collection assertion methods. Since producing comparers is a separate feature of itself that can be useful, I decided to break of those commits to include in this PR instead.

In addition to creating a `UnitEqualityComparer`, a `UnitComparer` was also created and used for all calls to `Sort` and as the main comparer for `SortedList` instances. It is better to use the comparer instead of the `CompareTo` method in `Unit` since `CompareTo` is a method that must be defined due to `IUnit`. Because of that, different classes that implement `IUnit` can have different implementations of `CompareTo`, producing inconsistencies if the logic is different between the two types that implement `IUnit`. `UnitComparer` defines the `Compare` logic instead of it relying on other unit's `CompareTo` methods.

In the future, `IComparable<IUnit>` should be removed from `IUnit` to avoid different types that implement `IUnit` from having different implementations of `CompareTo`. Instead, `IComparable<Unit<T>>` should have been the interface implemented directly on `Unit<T>`. 

Resolves #76 