### PR TITLE
feat(acceleration): support subscript abbreviation as default

### DIFF
--- a/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
@@ -23,7 +23,7 @@ public class AccelerationTests
     /// </remarks>
     internal static AccelerationTestData[] AccelerationTestDataTuples =>
     [
-        new (Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second squared", "{0} meters per second squared", "Quantity.Unit.Acceleration.MetersPerSecondSquared")
+        new (Acceleration.MetersPerSecondPerSecond, "{0} m/s²", "1 meter per second squared", "{0} meters per second squared", "Quantity.Unit.Acceleration.MetersPerSecondSquared")
     ];
 
     internal static IEnumerable<object[]> AccelerationShortNameArgs

--- a/Elements.Quantity/Quantities/Basic/Acceleration.cs
+++ b/Elements.Quantity/Quantities/Basic/Acceleration.cs
@@ -46,7 +46,7 @@ namespace Elements.Quantity
 
         public static readonly Unit<Acceleration> MetersPerSecondPerSecond = new Unit<Acceleration>(1,
             new UnitGroup[] { UnitGroup.Common, UnitGroup.Metric },
-            new string[] { " m/s^2", " m/s/s" }, new string[] { " meters per second squared", " meter per second squared", " meters per second per second", " meter per second per second" });
+            new string[] { " m/s²", " m/s^2", " m/s/s" }, new string[] { " meters per second squared", " meter per second squared", " meters per second per second", " meter per second per second" });
 
         #endregion
 


### PR DESCRIPTION
This adds m/s² as a shortname (i.e., abbreviation) and as the default since other units do the same. m/s^2 is still supported and should still be parsable.

Resolves #75 