### PR TITLE
feat(quantity): add static member for getting default unit

### DIFF
--- a/Elements.Quantity.Tests/Core/UnitTests.cs
+++ b/Elements.Quantity.Tests/Core/UnitTests.cs
@@ -16,6 +16,8 @@ public class UnitTests
         .Concat(SharedArgsProvider.InvalidFormatArgs)
         .Select(argsData => new [] { argsData.formatNum, argsData.expectedValue });
 
+    internal static IEnumerable<double> Numbers => DataProvider.UnitQuantityShortNameNumberValues;
+
     /// <summary>
     /// Tests that the <see cref="Unit{T}.FormatAs(T, string, bool, string)"/> method correctly formats a
     /// unit's value using the specified string format.
@@ -31,5 +33,62 @@ public class UnitTests
 
         var formattedValue = unit.FormatAs(quantity, formatNum);
         Assert.AreEqual(expectedValue, formattedValue);
+    }
+
+    /// <summary>
+    /// Verifies that the default unit definition for a quantity returns the expected unit.
+    /// </summary>
+    [TestMethod]
+    public void DefaultUnitDefinition_WhenAccessed_ReturnsExpectedUnit()
+    {
+        Assert.AreSame(MockProvider.MockUnit, MockQuantity.DefaultUnitDefinition);
+    }
+
+    /// <summary>
+    /// Verifies that the default unit on an instance of a quantity returns the expected unit.
+    /// </summary>
+    /// <remarks>
+    /// This property is currently marked as obsolete. Once <see cref="IQuantity{TQuantity}.DefaultUnit"/> is removed,
+    /// this test should be removed as well.
+    /// </remarks>
+    [TestMethod]
+    public void DefaultUnitOnInstance_WhenAccessed_ReturnsExpectedUnit()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        var actualDefaultUnit = default(MockQuantity).DefaultUnit;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        Assert.AreSame(MockProvider.MockUnit, actualDefaultUnit);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Unit{T}.Parse(string, Unit{T})"/> can parse a number only string into a quantity using the
+    /// default unit's ratio.
+    /// </summary>
+    /// <param name="number">The number to parse.</param>
+    [TestMethod]
+    [DynamicData(nameof(Numbers))]
+    public void ParseString_NumberOnlyString_ParsesAsDefaultUnit(double number)
+    {
+        var expectedValue = new MockQuantity(number * MockProvider.MockUnit.Ratio);
+        var actualValue = Unit<MockQuantity>.Parse(number.ToString());
+
+        Assert.AreEqual(expectedValue, actualValue);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Unit{T}.TryParse(string, out T, Unit{T})"/> can parse a number only string into a quantity
+    /// using the default unit's ratio, returning <c>true</c> upon success.
+    /// </summary>
+    /// <param name="number">The number to parse.</param>
+    [TestMethod]
+    [DynamicData(nameof(Numbers))]
+    public void TryParseString_NumberOnlyString_ParsesAsDefaultUnit(double number)
+    {
+        var expectedValue = new MockQuantity(number * MockProvider.MockUnit.Ratio);
+        var hasParsed = Unit<MockQuantity>.TryParse(number.ToString(), out MockQuantity actualValue);
+
+        Assert.IsTrue(hasParsed);
+        Assert.AreEqual(expectedValue, actualValue);
     }
 }

--- a/Elements.Quantity.Tests/Mocks/MockQuantity.cs
+++ b/Elements.Quantity.Tests/Mocks/MockQuantity.cs
@@ -13,18 +13,20 @@ namespace Elements.Quantity.Test.Mocks
         public readonly double BaseValue;
         double IQuantity.BaseValue => BaseValue;
 
-        public Unit<MockQuantity> DefaultUnit => throw new NotImplementedException();
+        [Obsolete("Use 'Unit<MockQuantity>.DefaultUnitDefinition' instead.")]
+        public Unit<MockQuantity> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<MockQuantity> DefaultUnitDefinition => MockUnit;
 
         public string QuantityFamily => "Mock";
+
+        public static readonly Unit<MockQuantity> MockUnit = MockProvider.MockUnit;
 
         public MockQuantity(double baseValue = 0) : this() { BaseValue = baseValue; }
         public bool Equals(MockQuantity other) { return BaseValue == other.BaseValue; }
         public int CompareTo(MockQuantity other) { return BaseValue.CompareTo(other.BaseValue); }
 
-        public MockQuantity New(double baseValue)
-        {
-            throw new NotImplementedException();
-        }
+        public MockQuantity New(double baseValue) => new MockQuantity(baseValue);
 
         public MockQuantity Add(MockQuantity q)
         {

--- a/Elements.Quantity.Tests/Quantities/BaseQuantityCompoundFormattedTestData.cs
+++ b/Elements.Quantity.Tests/Quantities/BaseQuantityCompoundFormattedTestData.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Elements.Quantity.Test.Quantities;
+
+[TestClass]
+[ExcludeFromCodeCoverage]
+public abstract class BaseQuantityCompoundFormattedTests<TData, TQuantity> : BaseQuantityTests<TData, TQuantity>
+where TData : IQuantityCompoundFormattedTestData<TQuantity>
+where TQuantity : unmanaged, IQuantity<TQuantity>
+{
+    public static IEnumerable<object[]> PredefinedCompoundFormatInfoArgs =>
+        TData.CompoundFormatInfoDataTuples.Select(row => (object[])[row.Format, row.Value, row.ExpectedStr]);
+
+    /// <summary>
+    /// Test that <typeparamref name="TQuantity"/> is correctly formatted when using <see cref="CompoundFormatInfo{TQuantity}"/>
+    /// </summary>
+    /// <param name="format">Format Info used</param>
+    /// <param name="value">Quantity value in <see cref="TQuantity.DefaultUnit"/> Unit.</param>
+    /// <param name="expectedStr">Expected format result</param>
+    [TestMethod]
+    [DynamicData(nameof(PredefinedCompoundFormatInfoArgs))]
+    public void FormatQuantityAsCompound_PredefinedCompoundFormat_FormatsQuantityAsString(CompoundFormatInfo<TQuantity> format, double value, string expectedStr)
+    {
+        var quantity = default(TQuantity).New(value);
+        var resultStr = quantity.FormatCompound(format);
+
+        Assert.AreEqual(expectedStr, resultStr);
+    }
+}

--- a/Elements.Quantity.Tests/Quantities/BaseQuantityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/BaseQuantityTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Elements.Quantity.Test.Quantities;
+
+[TestClass]
+[ExcludeFromCodeCoverage]
+public abstract class BaseQuantityTests<TData, TQuantity>
+where TData : IQuantityTestData<TQuantity>
+where TQuantity : unmanaged, IQuantity<TQuantity>
+{
+    private static QuantityTestData<TQuantity>[] TestDataTuples => TData.TestDataTuples;
+
+    public static IEnumerable<object[]> PredefinedCompoundFormatInfoArgs =>
+        TData.CompoundFormatInfoDataTuples?.Select(row => (object[])[row.Format, row.Value, row.ExpectedStr])
+        // No test cases => yield one null entry to prevent MSTest from failing
+        ?? [(object?[])[null, 0d, ""]];
+
+    /// <summary>
+    /// A collection of test data containing the <typeparamref name="TQuantity"/> unit, the numeric value, and the expected
+    /// formatted short name.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    public static IEnumerable<object[]> ShortNameArgs
+    {
+        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
+            TestDataTuples.Select(quantityUnitArgs => new object[] {
+                quantityUnitArgs.unit, numValue, string.Format(quantityUnitArgs.shortName, numValue)
+            }).ToArray()
+        );
+    }
+
+    /// <summary>
+    /// A collection of test data containing the <typeparamref name="TQuantity"/> unit and the expected formatted long
+    /// name for singluar values.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    public static IEnumerable<object[]> LongNameSingularFormArgs
+    {
+        get => TestDataTuples.Select(quantityUnitArgs => new object[] {
+            quantityUnitArgs.unit, quantityUnitArgs.longNameSingle
+        });
+    }
+
+    /// <summary>
+    /// A collection of test data containing the <typeparamref name="TQuantity"/> unit, the numeric value, and the expected
+    /// formatted long name for plural values.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    public static IEnumerable<object[]> LongNamePluralFormArgs
+    {
+        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
+            TestDataTuples.Select(quantityUnitArgs => new object[] {
+                quantityUnitArgs.unit, numValue, string.Format(quantityUnitArgs.longNamePlural, numValue)
+            }).ToArray()
+        );
+    }
+
+    /// <summary>
+    /// A collection of test arguments for verifying the unit keys for <typeparamref name="TQuantity"/> units.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    public static IEnumerable<ValueTuple<Unit<TQuantity>, string>> UnitKeyArgs =>
+        TestDataTuples.Select(unitArgs => (unitArgs.unit, unitArgs.unitKey));
+
+    /// <summary>
+    /// Verifies that formatting a <typeparamref name="TQuantity"/> quantity using the specified unit and the default short name produces the
+    /// expected string representation.
+    /// </summary>
+    /// <remarks>
+    /// This test ensures that the FormatAs method correctly applies the unit's default short name
+    /// when formatting a <typeparamref name="TQuantity"/> value. It uses dynamic data to validate multiple unit and string
+    /// combinations.
+    /// </remarks>
+    /// <param name="unit">The quantity unit to use when formatting the value.</param>
+    /// <param name="value">The numeric value to be formatted.</param>
+    /// <param name="expectedStr">
+    /// The expected string result when formatting the <typeparamref name="TQuantity"/> value with
+    /// the specified unit's default short name.
+    /// </param>
+    [TestMethod]
+    [DynamicData(nameof(ShortNameArgs))]
+    public void QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(
+        Unit<TQuantity> unit, double value, string expectedStr)
+    {
+        var quantity = unit.ConvertFrom(value);
+        var resultStr = quantity.FormatAs(unit, formatNum: "0.#");
+
+        Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that formatting a <typeparamref name="TQuantity"/> value using the specified unit with the long name option produces
+    /// the expected singular long name string for singular values.
+    /// </summary>
+    /// <remarks>
+    /// This test ensures that the FormatAs method correctly applies the singular form of the
+    /// unit's long name when formatting <typeparamref name="TQuantity"/> values.
+    /// </remarks>
+    /// <param name="unit">The quantity unit to use when formatting the value.</param>
+    /// <param name="expectedStr">The expected string result when formatting the quantity value with the long name option.</param>
+    [TestMethod]
+    [DynamicData(nameof(LongNameSingularFormArgs))]
+    public void QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(
+        Unit<TQuantity> unit, string expectedStr)
+    {
+        var quantity = unit.ConvertFrom(1d);
+        var resultStr = quantity.FormatAs(unit, longName: true, formatNum: "0.#");
+
+        Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that formatting a <typeparamref name="TQuantity"/> value using the specified unit with the long name option produces
+    /// the expected plural long name string for plural values.
+    /// </summary>
+    /// <remarks>
+    /// This test ensures that the FormatAs method correctly applies the plural form of the
+    /// unit's long name when formatting <typeparamref name="TQuantity"/> values.
+    /// </remarks>
+    /// <param name="unit">The quantity unit to use when formatting the value.</param>
+    /// <param name="value">The numeric value to be formatted.</param>
+    /// <param name="expectedStr">The expected string result when formatting the quantity value with the long name option.</param>
+    [TestMethod]
+    [DynamicData(nameof(LongNamePluralFormArgs))]
+    public void QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(
+        Unit<TQuantity> unit, double value, string expectedStr)
+    {
+        var quantity = unit.ConvertFrom(value);
+        var resultStr = quantity.FormatAs(unit, longName: true, formatNum: "0.#");
+
+        Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that getting a unit key from a <typeparamref name="TQuantity"/> unit will return the expected unit key.
+    /// </summary>
+    /// <param name="unit">The quantity unit to use when getting the unit key.</param>
+    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
+    [TestMethod]
+    [DynamicData(nameof(UnitKeyArgs))]
+    public void GetQuantityUnitKey_ValidUnit_ReturnsUnitKey(Unit<TQuantity> unit, string expectedUnitKey)
+    {
+        Assert.AreEqual(expectedUnitKey, unit.UnitKey);
+    }
+
+    /// <summary>
+    /// Test that <typeparamref name="TQuantity"/> is correctly formatted when using <see cref="CompoundFormatInfo{TQuantity}"/>
+    /// </summary>
+    /// <param name="format">Format Info used</param>
+    /// <param name="value">Quantity value in <see cref="TQuantity.DefaultUnit"/> Unit.</param>
+    /// <param name="expectedStr">Expected format result</param>
+    [TestMethod]
+    [DynamicData(nameof(PredefinedCompoundFormatInfoArgs))]
+    public void DistanceUnit_PredefinedQuantityCompoundFormatInfo_FormatsQuantityAsString(CompoundFormatInfo<TQuantity>? format, double value, string expectedStr)
+    {
+        // Skip if no tests are to be run (single null row)
+        if (format is null) Assert.Inconclusive();
+
+        var quantity = default(TQuantity).New(value);
+        var resultStr = quantity.FormatCompound(format);
+
+        Assert.AreEqual(expectedStr, resultStr);
+    }
+}

--- a/Elements.Quantity.Tests/Quantities/BaseQuantityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/BaseQuantityTests.cs
@@ -14,11 +14,6 @@ where TQuantity : unmanaged, IQuantity<TQuantity>
 {
     private static QuantityTestData<TQuantity>[] TestDataTuples => TData.TestDataTuples;
 
-    public static IEnumerable<object[]> PredefinedCompoundFormatInfoArgs =>
-        TData.CompoundFormatInfoDataTuples?.Select(row => (object[])[row.Format, row.Value, row.ExpectedStr])
-        // No test cases => yield one null entry to prevent MSTest from failing
-        ?? [(object?[])[null, 0d, ""]];
-
     /// <summary>
     /// A collection of test data containing the <typeparamref name="TQuantity"/> unit, the numeric value, and the expected
     /// formatted short name.
@@ -91,7 +86,7 @@ where TQuantity : unmanaged, IQuantity<TQuantity>
     /// </param>
     [TestMethod]
     [DynamicData(nameof(ShortNameArgs))]
-    public void QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(
+    public void FormatQuantity_ShortNameFormat_FormatsWithDefaultShortName(
         Unit<TQuantity> unit, double value, string expectedStr)
     {
         var quantity = unit.ConvertFrom(value);
@@ -112,7 +107,7 @@ where TQuantity : unmanaged, IQuantity<TQuantity>
     /// <param name="expectedStr">The expected string result when formatting the quantity value with the long name option.</param>
     [TestMethod]
     [DynamicData(nameof(LongNameSingularFormArgs))]
-    public void QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(
+    public void FormatSingularQuantity_LongNameFormat_FormatsWithDefaultLongNameSingularForm(
         Unit<TQuantity> unit, string expectedStr)
     {
         var quantity = unit.ConvertFrom(1d);
@@ -134,7 +129,7 @@ where TQuantity : unmanaged, IQuantity<TQuantity>
     /// <param name="expectedStr">The expected string result when formatting the quantity value with the long name option.</param>
     [TestMethod]
     [DynamicData(nameof(LongNamePluralFormArgs))]
-    public void QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(
+    public void FormatPluralQuantity_LongNameFormat_FormatsWithDefaultLongNamePluralForm(
         Unit<TQuantity> unit, double value, string expectedStr)
     {
         var quantity = unit.ConvertFrom(value);
@@ -153,24 +148,5 @@ where TQuantity : unmanaged, IQuantity<TQuantity>
     public void GetQuantityUnitKey_ValidUnit_ReturnsUnitKey(Unit<TQuantity> unit, string expectedUnitKey)
     {
         Assert.AreEqual(expectedUnitKey, unit.UnitKey);
-    }
-
-    /// <summary>
-    /// Test that <typeparamref name="TQuantity"/> is correctly formatted when using <see cref="CompoundFormatInfo{TQuantity}"/>
-    /// </summary>
-    /// <param name="format">Format Info used</param>
-    /// <param name="value">Quantity value in <see cref="TQuantity.DefaultUnit"/> Unit.</param>
-    /// <param name="expectedStr">Expected format result</param>
-    [TestMethod]
-    [DynamicData(nameof(PredefinedCompoundFormatInfoArgs))]
-    public void DistanceUnit_PredefinedQuantityCompoundFormatInfo_FormatsQuantityAsString(CompoundFormatInfo<TQuantity>? format, double value, string expectedStr)
-    {
-        // Skip if no tests are to be run (single null row)
-        if (format is null) Assert.Inconclusive();
-
-        var quantity = default(TQuantity).New(value);
-        var resultStr = quantity.FormatCompound(format);
-
-        Assert.AreEqual(expectedStr, resultStr);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/BaseQuantityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/BaseQuantityTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -13,6 +13,11 @@ where TData : IQuantityTestData<TQuantity>
 where TQuantity : unmanaged, IQuantity<TQuantity>
 {
     private static QuantityTestData<TQuantity>[] TestDataTuples => TData.TestDataTuples;
+
+    /// <summary>
+    /// The expected default unit for the given quantity type.
+    /// </summary>
+    public abstract Unit<TQuantity> ExpectedDefaultUnit { get; }
 
     /// <summary>
     /// A collection of test data containing the <typeparamref name="TQuantity"/> unit, the numeric value, and the expected
@@ -70,8 +75,8 @@ where TQuantity : unmanaged, IQuantity<TQuantity>
         TestDataTuples.Select(unitArgs => (unitArgs.unit, unitArgs.unitKey));
 
     /// <summary>
-    /// Verifies that formatting a <typeparamref name="TQuantity"/> quantity using the specified unit and the default short name produces the
-    /// expected string representation.
+    /// Verifies that formatting a <typeparamref name="TQuantity"/> quantity using the specified unit and the default short
+    /// name produces the expected string representation.
     /// </summary>
     /// <remarks>
     /// This test ensures that the FormatAs method correctly applies the unit's default short name
@@ -121,8 +126,8 @@ where TQuantity : unmanaged, IQuantity<TQuantity>
     /// the expected plural long name string for plural values.
     /// </summary>
     /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the plural form of the
-    /// unit's long name when formatting <typeparamref name="TQuantity"/> values.
+    /// This test ensures that the FormatAs method correctly applies the plural form of the unit's long name
+    /// when formatting <typeparamref name="TQuantity"/> values.
     /// </remarks>
     /// <param name="unit">The quantity unit to use when formatting the value.</param>
     /// <param name="value">The numeric value to be formatted.</param>
@@ -136,6 +141,59 @@ where TQuantity : unmanaged, IQuantity<TQuantity>
         var resultStr = quantity.FormatAs(unit, longName: true, formatNum: "0.#");
 
         Assert.AreEqual(expectedStr, resultStr);
+    }
+
+    /// <summary>
+    /// Verifies that auto formatting a <typeparamref name="TQuantity"/> whose base value is zero returns the
+    /// expected string representation.
+    /// </summary>
+    /// <remarks>
+    /// This test ensures that the default unit's short name and long name are correctly used when formatting a
+    /// <typeparamref name="TQuantity"/> with a base value of zero.
+    /// </remarks>
+    /// <param name="useLongName">Indicates whether or not to use the long name of the default unit.</param>
+    /// <param name="failureMessage">The message to display if the test fails.</param>
+    [TestMethod(UnfoldingStrategy = TestDataSourceUnfoldingStrategy.Unfold)]
+    [DataRow(false, "The auto formatted string should use the default unit's short name.")]
+    [DataRow(true, "The auto formatted string should use the default unit's long name.")]
+    public void FormatAutoQuantity_BaseValueZero_FormatsWithDefaultName(bool useLongName, string failureMessage)
+    {
+        var defaultName = useLongName
+            ? ExpectedDefaultUnit.DefaultLongUnitNamePluralForm
+            : ExpectedDefaultUnit.DefaultShortUnitName;
+
+        var expectedValue = $"0{defaultName}";
+
+        var quantity = default(TQuantity);
+        var actualValue = quantity.FormatAuto(longName: useLongName);
+
+        Assert.AreEqual(expectedValue, actualValue, failureMessage);
+    }
+
+    /// <summary>
+    /// Verifies that the default unit definition for a <typeparamref name="TQuantity"/> returns the expected unit.
+    /// </summary>
+    [TestMethod]
+    public void DefaultUnitDefinition_WhenAccessed_ReturnsExpectedUnit()
+    {
+        Assert.AreSame(ExpectedDefaultUnit, TQuantity.DefaultUnitDefinition);
+    }
+
+    /// <summary>
+    /// Verifies that the default unit on an instance of a <typeparamref name="TQuantity"/> returns the expected unit.
+    /// </summary>
+    /// <remarks>
+    /// This property is currently marked as obsolete. Once <see cref="IQuantity{TQuantity}.DefaultUnit"/> is removed,
+    /// this test should be removed as well.
+    /// </remarks>
+    [TestMethod]
+    public void DefaultUnitOnInstance_WhenAccessed_ReturnsExpectedUnit()
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        var actualDefaultUnit = default(TQuantity).DefaultUnit;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        Assert.AreSame(ExpectedDefaultUnit, actualDefaultUnit);
     }
 
     /// <summary>

--- a/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
@@ -1,104 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using AccelerationTestData = QuantityTestData<Acceleration>;
-using AccelerationUnitKeyTestData = (Unit<Acceleration> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class AccelerationTests
+public sealed class AccelerationTests : BaseQuantityTests<AccelerationTests, Acceleration>, IQuantityTestData<Acceleration>
 {
-    /// <summary>
-    /// An array of test data tuples representing different acceleration units and their display formats. Each
-    /// element in the array contains information about a acceleration unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static AccelerationTestData[] AccelerationTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Acceleration>[] TestDataTuples =>
     [
-        new (Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second squared", "{0} meters per second squared", "Quantity.Unit.Acceleration.MetersPerSecondSquared")
+        new(Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second squared", "{0} meters per second squared", "Quantity.Unit.Acceleration.MetersPerSecondSquared")
     ];
 
-    internal static IEnumerable<object[]> AccelerationShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            AccelerationTestDataTuples.Select(accelerationUnitArgs => new object[] {
-                accelerationUnitArgs.unit, numValue, string.Format(accelerationUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> AccelerationLongNameSingularFormArgs
-    {
-        get => AccelerationTestDataTuples.Select(accelerationUnitArgs => new object[] {
-            accelerationUnitArgs.unit, accelerationUnitArgs.longNameSingle
-        });
-    }
-
-    internal static IEnumerable<object[]> AccelerationLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            AccelerationTestDataTuples.Select(accelerationUnitArgs => new object[] {
-                accelerationUnitArgs.unit, numValue, string.Format(accelerationUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for acceleration units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<AccelerationUnitKeyTestData> AccelerationUnitKeyArgs =>
-        AccelerationTestDataTuples.Select(unitArgs => new AccelerationUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(AccelerationShortNameArgs))]
-    public void AccelerationUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Acceleration> accelerationUnit, double accelerationValue, string expectedStr)
-    {
-        var acceleration = new Acceleration(accelerationValue * accelerationUnit.Ratio);
-        var resultStr = acceleration.FormatAs(accelerationUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(AccelerationLongNameSingularFormArgs))]
-    public void AccelerationUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Acceleration> accelerationUnit, string expectedStr)
-    {
-        var acceleration = new Acceleration(accelerationUnit.Ratio);
-        var resultStr = acceleration.FormatAs(accelerationUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(AccelerationLongNamePluralFormArgs))]
-    public void AccelerationUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Acceleration> accelerationUnit, double accelerationValue, string expectedStr)
-    {
-        var acceleration = new Acceleration(accelerationValue * accelerationUnit.Ratio);
-        var resultStr = acceleration.FormatAs(accelerationUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Acceleration unit will return the expected unit key.
-    /// </summary>
-    /// <param name="accelerationUnit">The acceleration unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(AccelerationUnitKeyArgs))]
-    public void GetAccelerationUnitKey_ValidUnit_ReturnsUnitKey(Unit<Acceleration> accelerationUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, accelerationUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Acceleration>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
@@ -13,7 +12,4 @@ public sealed class AccelerationTests : BaseQuantityTests<AccelerationTests, Acc
     [
         new(Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second squared", "{0} meters per second squared", "Quantity.Unit.Acceleration.MetersPerSecondSquared")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Acceleration>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AccelerationTests.cs
@@ -12,4 +12,7 @@ public sealed class AccelerationTests : BaseQuantityTests<AccelerationTests, Acc
     [
         new(Acceleration.MetersPerSecondPerSecond, "{0} m/s^2", "1 meter per second squared", "{0} meters per second squared", "Quantity.Unit.Acceleration.MetersPerSecondSquared")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Acceleration> ExpectedDefaultUnit => Acceleration.MetersPerSecondPerSecond;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/AngleTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AngleTests.cs
@@ -7,7 +7,7 @@ namespace Elements.Quantity.Test.Quantities.Basic;
 
 [TestClass]
 [ExcludeFromCodeCoverage]
-public sealed class AngleTests : BaseQuantityTests<AngleTests, Angle>, IQuantityTestData<Angle>
+public sealed class AngleTests : BaseQuantityCompoundFormattedTests<AngleTests, Angle>, IQuantityCompoundFormattedTestData<Angle>
 {
     /// <inheritdoc/>
     public static QuantityTestData<Angle>[] TestDataTuples =>

--- a/Elements.Quantity.Tests/Quantities/Basic/AngleTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AngleTests.cs
@@ -2,159 +2,66 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using AngleTestData = QuantityTestData<Angle>;
-using AngleUnitKeyTestData = (Unit<Angle> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class AngleTests
+public sealed class AngleTests : BaseQuantityTests<AngleTests, Angle>, IQuantityTestData<Angle>
 {
-    /// <summary>
-    /// An array of test data tuples representing different angle units and their display formats. Each
-    /// element in the array contains information about a angle unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static AngleTestData[] AngleTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Angle>[] TestDataTuples =>
     [
-        new (Angle.Radian, "{0} rad", "1 radian", "{0} radians", "Quantity.Unit.Angle.Radians"),
-        new (Angle.Degree, "{0}°", "1 degree", "{0} degrees", "Quantity.Unit.Angle.Degrees"),
-        new (Angle.ArcMinute, "{0}′", "1 arcminute", "{0} arcminutes", "Quantity.Unit.Angle.Arcminutes"),
-        new (Angle.ArcSecond, "{0}″", "1 arcsecond", "{0} arcseconds", "Quantity.Unit.Angle.Arcseconds"),
-        new (SI<Angle>.Quecto, "{0} qrad", "1 quectoradian", "{0} quectoradians", "Quantity.Unit.Angle.Quectoradians"),
-        new (SI<Angle>.Ronto, "{0} rrad", "1 rontoradian", "{0} rontoradians", "Quantity.Unit.Angle.Rontoradians"),
-        new (SI<Angle>.Yocto, "{0} yrad", "1 yoctoradian", "{0} yoctoradians", "Quantity.Unit.Angle.Yoctoradians"),
-        new (SI<Angle>.Zepto, "{0} zrad", "1 zeptoradian", "{0} zeptoradians", "Quantity.Unit.Angle.Zeptoradians"),
-        new (SI<Angle>.Atto, "{0} arad", "1 attoradian", "{0} attoradians", "Quantity.Unit.Angle.Attoradians"),
-        new (SI<Angle>.Femto, "{0} frad", "1 femtoradian", "{0} femtoradians", "Quantity.Unit.Angle.Femtoradians"),
-        new (SI<Angle>.Pico, "{0} prad", "1 picoradian", "{0} picoradians", "Quantity.Unit.Angle.Picoradians"),
-        new (SI<Angle>.Nano, "{0} nrad", "1 nanoradian", "{0} nanoradians", "Quantity.Unit.Angle.Nanoradians"),
-        new (SI<Angle>.Micro, "{0} µrad", "1 microradian", "{0} microradians", "Quantity.Unit.Angle.Microradians"),
-        new (SI<Angle>.Centi, "{0} crad", "1 centiradian", "{0} centiradians", "Quantity.Unit.Angle.Centiradians"),
-        new (SI<Angle>.Deci, "{0} drad", "1 deciradian", "{0} deciradians", "Quantity.Unit.Angle.Deciradians"),
-        new (SI<Angle>.Deca, "{0} darad", "1 decaradian", "{0} decaradians", "Quantity.Unit.Angle.Decaradians"),
-        new (SI<Angle>.Hecto, "{0} hrad", "1 hectoradian", "{0} hectoradians", "Quantity.Unit.Angle.Hectoradians"),
-        new (SI<Angle>.Milli, "{0} mrad", "1 milliradian", "{0} milliradians", "Quantity.Unit.Angle.Milliradians"),
-        new (SI<Angle>.Kilo, "{0} krad", "1 kiloradian", "{0} kiloradians", "Quantity.Unit.Angle.Kiloradians"),
-        new (SI<Angle>.Mega, "{0} Mrad", "1 megaradian", "{0} megaradians", "Quantity.Unit.Angle.Megaradians"),
-        new (SI<Angle>.Giga, "{0} Grad", "1 gigaradian", "{0} gigaradians", "Quantity.Unit.Angle.Gigaradians"),
-        new (SI<Angle>.Tera, "{0} Trad", "1 teraradian", "{0} teraradians", "Quantity.Unit.Angle.Teraradians"),
-        new (SI<Angle>.Peta, "{0} Prad", "1 petaradian", "{0} petaradians", "Quantity.Unit.Angle.Petaradians"),
-        new (SI<Angle>.Exa, "{0} Erad", "1 exaradian", "{0} exaradians", "Quantity.Unit.Angle.Exaradians"),
-        new (SI<Angle>.Zetta, "{0} Zrad", "1 zettaradian", "{0} zettaradians", "Quantity.Unit.Angle.Zettaradians"),
-        new (SI<Angle>.Yotta, "{0} Yrad", "1 yottaradian", "{0} yottaradians", "Quantity.Unit.Angle.Yottaradians"),
-        new (SI<Angle>.Ronna, "{0} Rrad", "1 ronnaradian", "{0} ronnaradians", "Quantity.Unit.Angle.Ronnaradians"),
-        new (SI<Angle>.Quetta, "{0} Qrad", "1 quettaradian", "{0} quettaradians", "Quantity.Unit.Angle.Quettaradians")
+        new(Angle.Radian, "{0} rad", "1 radian", "{0} radians", "Quantity.Unit.Angle.Radians"),
+        new(Angle.Degree, "{0}°", "1 degree", "{0} degrees", "Quantity.Unit.Angle.Degrees"),
+        new(Angle.ArcMinute, "{0}′", "1 arcminute", "{0} arcminutes", "Quantity.Unit.Angle.Arcminutes"),
+        new(Angle.ArcSecond, "{0}″", "1 arcsecond", "{0} arcseconds", "Quantity.Unit.Angle.Arcseconds"),
+        new(SI<Angle>.Quecto, "{0} qrad", "1 quectoradian", "{0} quectoradians", "Quantity.Unit.Angle.Quectoradians"),
+        new(SI<Angle>.Ronto, "{0} rrad", "1 rontoradian", "{0} rontoradians", "Quantity.Unit.Angle.Rontoradians"),
+        new(SI<Angle>.Yocto, "{0} yrad", "1 yoctoradian", "{0} yoctoradians", "Quantity.Unit.Angle.Yoctoradians"),
+        new(SI<Angle>.Zepto, "{0} zrad", "1 zeptoradian", "{0} zeptoradians", "Quantity.Unit.Angle.Zeptoradians"),
+        new(SI<Angle>.Atto, "{0} arad", "1 attoradian", "{0} attoradians", "Quantity.Unit.Angle.Attoradians"),
+        new(SI<Angle>.Femto, "{0} frad", "1 femtoradian", "{0} femtoradians", "Quantity.Unit.Angle.Femtoradians"),
+        new(SI<Angle>.Pico, "{0} prad", "1 picoradian", "{0} picoradians", "Quantity.Unit.Angle.Picoradians"),
+        new(SI<Angle>.Nano, "{0} nrad", "1 nanoradian", "{0} nanoradians", "Quantity.Unit.Angle.Nanoradians"),
+        new(SI<Angle>.Micro, "{0} µrad", "1 microradian", "{0} microradians", "Quantity.Unit.Angle.Microradians"),
+        new(SI<Angle>.Centi, "{0} crad", "1 centiradian", "{0} centiradians", "Quantity.Unit.Angle.Centiradians"),
+        new(SI<Angle>.Deci, "{0} drad", "1 deciradian", "{0} deciradians", "Quantity.Unit.Angle.Deciradians"),
+        new(SI<Angle>.Deca, "{0} darad", "1 decaradian", "{0} decaradians", "Quantity.Unit.Angle.Decaradians"),
+        new(SI<Angle>.Hecto, "{0} hrad", "1 hectoradian", "{0} hectoradians", "Quantity.Unit.Angle.Hectoradians"),
+        new(SI<Angle>.Milli, "{0} mrad", "1 milliradian", "{0} milliradians", "Quantity.Unit.Angle.Milliradians"),
+        new(SI<Angle>.Kilo, "{0} krad", "1 kiloradian", "{0} kiloradians", "Quantity.Unit.Angle.Kiloradians"),
+        new(SI<Angle>.Mega, "{0} Mrad", "1 megaradian", "{0} megaradians", "Quantity.Unit.Angle.Megaradians"),
+        new(SI<Angle>.Giga, "{0} Grad", "1 gigaradian", "{0} gigaradians", "Quantity.Unit.Angle.Gigaradians"),
+        new(SI<Angle>.Tera, "{0} Trad", "1 teraradian", "{0} teraradians", "Quantity.Unit.Angle.Teraradians"),
+        new(SI<Angle>.Peta, "{0} Prad", "1 petaradian", "{0} petaradians", "Quantity.Unit.Angle.Petaradians"),
+        new(SI<Angle>.Exa, "{0} Erad", "1 exaradian", "{0} exaradians", "Quantity.Unit.Angle.Exaradians"),
+        new(SI<Angle>.Zetta, "{0} Zrad", "1 zettaradian", "{0} zettaradians", "Quantity.Unit.Angle.Zettaradians"),
+        new(SI<Angle>.Yotta, "{0} Yrad", "1 yottaradian", "{0} yottaradians", "Quantity.Unit.Angle.Yottaradians"),
+        new(SI<Angle>.Ronna, "{0} Rrad", "1 ronnaradian", "{0} ronnaradians", "Quantity.Unit.Angle.Ronnaradians"),
+        new(SI<Angle>.Quetta, "{0} Qrad", "1 quettaradian", "{0} quettaradians", "Quantity.Unit.Angle.Quettaradians")
     ];
 
-    internal static IEnumerable<object[]> AngleShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            AngleTestDataTuples.Select(angleUnitArgs => new object[] {
-                    angleUnitArgs.unit, numValue, string.Format(angleUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Angle>> CompoundFormatInfoDataTuples =>
+    [
+        new(Angle.DegreeMinSec, 0d, ""),
+        new(Angle.DegreeMinSec, 0.25d, "14°19′26″"),
+        new(Angle.DegreeMinSec, 0.5d, "28°38′52″"),
+        new(Angle.DegreeMinSec, 0.96d, "55°14″"),
+        new(Angle.DegreeMinSec, 1d, "57°17′45″"),
+        new(Angle.DegreeMinSec, 1.25d, "71°37′11″"),
 
-    internal static IEnumerable<object[]> AngleLongNameSingularFormArgs
-    {
-        get => AngleTestDataTuples.Select(angleUnitArgs => new object[] {
-                angleUnitArgs.unit, angleUnitArgs.longNameSingle
-            });
-    }
+        // Constructed using constants, to match the expected values from before #17
+        new(Angle.DegreeMinSec, Math.PI/180d, "1°"),
+        new(Angle.DegreeMinSec, Math.PI/180d + Math.PI/648000d, "1°1″"),
+        new(Angle.DegreeMinSec, Math.PI/180d + Math.PI/10800d + Math.PI/648000d, "1°1′1″"),
+    ];
 
-    internal static IEnumerable<object[]> AngleLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            AngleTestDataTuples.Select(angleUnitArgs => new object[] {
-                    angleUnitArgs.unit, numValue, string.Format(angleUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> AnglePredefinedCompoundFormatInfoArgs
-    {
-        get => new object[][]
-        {
-            [Angle.DegreeMinSec, 0d, ""],
-            [Angle.DegreeMinSec, 0.25d, "14°19′26″"],
-            [Angle.DegreeMinSec, 0.5d, "28°38′52″"],
-            [Angle.DegreeMinSec, 0.96d, "55°14″"],
-            [Angle.DegreeMinSec, 1d, "57°17′45″"],
-            [Angle.DegreeMinSec, 1.25d, "71°37′11″"],
-
-            // Constructed using constants, to match the expected values from before #17
-            [Angle.DegreeMinSec, Math.PI/180d, "1°"],
-            [Angle.DegreeMinSec, Math.PI/180d + Math.PI/648000d, "1°1″"],
-            [Angle.DegreeMinSec, Math.PI/180d + Math.PI/10800d + Math.PI/648000d, "1°1′1″"]
-        };
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for angle units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<AngleUnitKeyTestData> AngleUnitKeyArgs =>
-        AngleTestDataTuples.Select(unitArgs => new AngleUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(AngleShortNameArgs))]
-    public void AngleUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Angle> angleUnit, double angleValue, string expectedStr)
-    {
-        var angle = new Angle(angleValue * angleUnit.Ratio);
-        var resultStr = angle.FormatAs(angleUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(AngleLongNameSingularFormArgs))]
-    public void AngleUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Angle> angleUnit, string expectedStr)
-    {
-        var angle = new Angle(angleUnit.Ratio);
-        var resultStr = angle.FormatAs(angleUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(AngleLongNamePluralFormArgs))]
-    public void AngleUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Angle> angleUnit, double angleValue, string expectedStr)
-    {
-        var angle = new Angle(angleValue * angleUnit.Ratio);
-        var resultStr = angle.FormatAs(angleUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Test that Angle's are correctly formatted when using <see cref="CompoundFormatInfo{Angle}"/>
-    /// </summary>
-    /// <param name="angleCompoundFormatInfo">Format Info used</param>
-    /// <param name="angleValue">Angle value in <see cref="Angle.DefaultUnit"/> Unit.</param>
-    /// <param name="expectedStr">Expected format result</param>
-    [TestMethod]
-    [DynamicData(nameof(AnglePredefinedCompoundFormatInfoArgs))]
-    public void AngleUnit_PredefinedQuantityCompoundFormatInfo_FormatsQuantityAsString(CompoundFormatInfo<Angle> angleCompoundFormatInfo, double angleValue, string expectedStr)
-    {
-        var angle = new Angle(angleValue);
-        var resultStr = angle.FormatCompound(angleCompoundFormatInfo);
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [DataRow(Math.PI/2, 90d)]
-    [DataRow(Math.PI/4, 45d)]
+    [DataRow(Math.PI / 2, 90d)]
+    [DataRow(Math.PI / 4, 45d)]
     [DataRow(Math.PI, 180d)]
-    [DataRow(Math.PI*2, 360d)]
+    [DataRow(Math.PI * 2, 360d)]
     [TestMethod]
     public void RadianToDegrees(double radians, double degrees)
     {
@@ -163,27 +70,15 @@ public class AngleTests
         Assert.AreEqual(degrees, angle.ConvertTo(Angle.Degree), 0.1);
     }
 
-    [DataRow(90d, Math.PI/2)]
-    [DataRow(45d, Math.PI/4)]
+    [DataRow(90d, Math.PI / 2)]
+    [DataRow(45d, Math.PI / 4)]
     [DataRow(180d, Math.PI)]
-    [DataRow(360d, Math.PI*2)]
+    [DataRow(360d, Math.PI * 2)]
     [TestMethod]
     public void DegreesToRadians(double degrees, double radians)
     {
         var angle = Angle.Degree.ConvertFrom(degrees);
 
         Assert.AreEqual(radians, angle.BaseValue, 0.0001);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Angle unit will return the expected unit key.
-    /// </summary>
-    /// <param name="angleUnit">The angle unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(AngleUnitKeyArgs))]
-    public void GetAngleUnitKey_ValidUnit_ReturnsUnitKey(Unit<Angle> angleUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, angleUnit.UnitKey);
     }
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/AngleTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/AngleTests.cs
@@ -58,6 +58,9 @@ public sealed class AngleTests : BaseQuantityCompoundFormattedTests<AngleTests, 
         new(Angle.DegreeMinSec, Math.PI/180d + Math.PI/10800d + Math.PI/648000d, "1°1′1″"),
     ];
 
+    /// <inheritdoc/>
+    public sealed override Unit<Angle> ExpectedDefaultUnit => Angle.Radian;
+
     [DataRow(Math.PI / 2, 90d)]
     [DataRow(Math.PI / 4, 45d)]
     [DataRow(Math.PI, 180d)]

--- a/Elements.Quantity.Tests/Quantities/Basic/DensityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DensityTests.cs
@@ -1,159 +1,21 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using DensityTestData = QuantityTestData<Density>;
-using DensityUnitKeyTestData = (Unit<Density> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class DensityTests
+public class DensityTests : BaseQuantityTests<DensityTests, Density>, IQuantityTestData<Density>
 {
-    /// <summary>
-    /// An array of test data tuples representing different density units and their display formats. Each
-    /// element in the array contains information about a density unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static DensityTestData[] DensityTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Density>[] TestDataTuples =>
     [
-        new (Density.KilogramPerCubicMeter, "{0} kg/m³", "1 kilogram per cubic meter", "{0} kilograms per cubic meter", "Quantity.Unit.Density.KilogramsPerCubicMeter"),
-        new (Density.GramPerCubicCentimeter, "{0} g/cm³", "1 gram per cubic centimeter", "{0} grams per cubic centimeter", "Quantity.Unit.Density.GramsPerCubicCentimeter"),
-        new (Density.PoundPerCubicFoot, "{0} lb/ft³", "1 pound per cubic foot", "{0} pounds per cubic foot", "Quantity.Unit.Density.PoundsPerCubicFoot")
+        new(Density.KilogramPerCubicMeter, "{0} kg/m³", "1 kilogram per cubic meter", "{0} kilograms per cubic meter", "Quantity.Unit.Density.KilogramsPerCubicMeter"),
+        new(Density.GramPerCubicCentimeter, "{0} g/cm³", "1 gram per cubic centimeter", "{0} grams per cubic centimeter", "Quantity.Unit.Density.GramsPerCubicCentimeter"),
+        new(Density.PoundPerCubicFoot, "{0} lb/ft³", "1 pound per cubic foot", "{0} pounds per cubic foot", "Quantity.Unit.Density.PoundsPerCubicFoot")
     ];
 
-    /// <summary>
-    /// A collection of test data containing the density unit, the numeric value, and the expected
-    /// formatted short name.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> DensityShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            DensityTestDataTuples.Select(densityUnitArgs => new object[] {
-                densityUnitArgs.unit, numValue, string.Format(densityUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test data containing the density unit and the expected formatted long
-    /// name for singluar values.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> DensityLongNameSingularFormArgs
-    {
-        get => DensityTestDataTuples.Select(densityUnitArgs => new object[] {
-            densityUnitArgs.unit, densityUnitArgs.longNameSingle
-        });
-    }
-
-    /// <summary>
-    /// A collection of test data containing the density unit, the numeric value, and the expected
-    /// formatted long name for plural values.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> DensityLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            DensityTestDataTuples.Select(densityUnitArgs => new object[] {
-                densityUnitArgs.unit, numValue, string.Format(densityUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for density units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<DensityUnitKeyTestData> DensityUnitKeyArgs =>
-        DensityTestDataTuples.Select(unitArgs => new DensityUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    /// <summary>
-    /// Verifies that formatting a Density quantity using the specified unit and the default short name produces the
-    /// expected string representation.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the unit's default short name
-    /// when formatting a density value. It uses dynamic data to validate multiple unit and string
-    /// combinations.
-    /// </remarks>
-    /// <param name="densityUnit">The density unit to use when formatting the value.</param>
-    /// <param name="densityValue">The numeric value to be formatted.</param>
-    /// <param name="expectedStr">The expected string result when formatting the density value with the specified unit's default short name.</param>
-    [TestMethod]
-    [DynamicData(nameof(DensityShortNameArgs))]
-    public void DensityUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Density> densityUnit, double densityValue, string expectedStr)
-    {
-        var density = new Density(densityValue * densityUnit.Ratio);
-        var resultStr = density.FormatAs(densityUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that formatting a density value using the specified unit with the long name option produces
-    /// the expected singular long name string for singular values.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the singular form of the
-    /// unit's long name when formatting density values.
-    /// </remarks>
-    /// <param name="densityUnit">The density unit to use when formatting the value.</param>
-    /// <param name="expectedStr">The expected string result when formatting the density value with the long name option.</param>
-    [TestMethod]
-    [DynamicData(nameof(DensityLongNameSingularFormArgs))]
-    public void DensityUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Density> densityUnit, string expectedStr)
-    {
-        var density = new Density(densityUnit.Ratio);
-        var resultStr = density.FormatAs(densityUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that formatting a density value using the specified unit with the long name option produces
-    /// the expected plural long name string for plural values.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the  plural form of the
-    /// unit's long name when formatting density values.
-    /// </remarks>
-    /// <param name="densityUnit">The density unit to use when formatting the value.</param>
-    /// <param name="densityValue">The numeric value to be formatted.</param>
-    /// <param name="expectedStr">The expected string result when formatting the density value with the long name option.</param>
-    [TestMethod]
-    [DynamicData(nameof(DensityLongNamePluralFormArgs))]
-    public void DensityUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Density> densityUnit, double densityValue, string expectedStr)
-    {
-        var density = new Density(densityValue * densityUnit.Ratio);
-        var resultStr = density.FormatAs(densityUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Density unit will return the expected unit key.
-    /// </summary>
-    /// <param name="densityUnit">The density unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(DensityUnitKeyArgs))]
-    public void GetDensityUnitKey_ValidUnit_ReturnsUnitKey(Unit<Density> densityUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, densityUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Density>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/DensityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DensityTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
@@ -15,7 +14,4 @@ public class DensityTests : BaseQuantityTests<DensityTests, Density>, IQuantityT
         new(Density.GramPerCubicCentimeter, "{0} g/cm³", "1 gram per cubic centimeter", "{0} grams per cubic centimeter", "Quantity.Unit.Density.GramsPerCubicCentimeter"),
         new(Density.PoundPerCubicFoot, "{0} lb/ft³", "1 pound per cubic foot", "{0} pounds per cubic foot", "Quantity.Unit.Density.PoundsPerCubicFoot")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Density>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/DensityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DensityTests.cs
@@ -14,4 +14,7 @@ public class DensityTests : BaseQuantityTests<DensityTests, Density>, IQuantityT
         new(Density.GramPerCubicCentimeter, "{0} g/cm³", "1 gram per cubic centimeter", "{0} grams per cubic centimeter", "Quantity.Unit.Density.GramsPerCubicCentimeter"),
         new(Density.PoundPerCubicFoot, "{0} lb/ft³", "1 pound per cubic foot", "{0} pounds per cubic foot", "Quantity.Unit.Density.PoundsPerCubicFoot")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Density> ExpectedDefaultUnit => Density.KilogramPerCubicMeter;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
@@ -1,164 +1,65 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using DistanceTestData = QuantityTestData<Distance>;
-using DistanceUnitKeyTestData = (Unit<Distance> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class DistanceTests
+public class DistanceTests : BaseQuantityTests<DistanceTests, Distance>, IQuantityTestData<Distance>
 {
-    /// <summary>
-    /// An array of test data tuples representing different distance units and their display formats. Each
-    /// element in the array contains information about a distance unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static DistanceTestData[] DistanceTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Distance>[] TestDataTuples =>
     [
-        new (Distance.AU, "{0} AU", "1 Astronomical Unit", "{0} Astronomical Units", "Quantity.Unit.Distance.AstronomicalUnits"),
-        new (Distance.Angstrom, "{0} Å", "1 ångström", "{0} ångströms", "Quantity.Unit.Distance.Ångströms"),
-        new (Distance.Foot, "{0} ft", "1 foot", "{0} feet", "Quantity.Unit.Distance.Feet"),
-        new (Distance.Inch, "{0} in", "1 inch", "{0} inches", "Quantity.Unit.Distance.Inches"),
-        new (Distance.Lightsecond, "{0} ls", "1 lightsecond", "{0} lightseconds", "Quantity.Unit.Distance.Lightseconds"),
-        new (Distance.Lightyear, "{0} ly", "1 lightyear", "{0} lightyears", "Quantity.Unit.Distance.Lightyears"),
-        new (Distance.Meter, "{0} m", "1 meter", "{0} meters", "Quantity.Unit.Distance.Meters"),
-        new (Distance.Mile, "{0} mi", "1 mile", "{0} miles", "Quantity.Unit.Distance.Miles"),
-        new (Distance.Parsec, "{0} pc", "1 parsec", "{0} parsecs", "Quantity.Unit.Distance.Parsecs"),
-        new (Distance.SolarRadius, "{0} R☉", "1 Solar radius", "{0} Solar radii", "Quantity.Unit.Distance.SolarRadii"),
-        new (Distance.Thou, "{0} th", "1 thou", "{0} thous", "Quantity.Unit.Distance.Thous"),
-        new (Distance.Yard, "{0} yd", "1 yard", "{0} yards", "Quantity.Unit.Distance.Yards"),
-        new (Distance.NauticalMile, "{0} NM", "1 nautical mile", "{0} nautical miles", "Quantity.Unit.Distance.NauticalMiles"),
-        new (Distance.Fathom, "{0} ftm", "1 fathom", "{0} fathoms", "Quantity.Unit.Distance.Fathoms"),
-        new (Distance.Chain, "{0} ch", "1 chain", "{0} chains", "Quantity.Unit.Distance.Chains"),
-        new (Distance.Rod, "{0} rd", "1 rod", "{0} rods", "Quantity.Unit.Distance.Rods"),
-        new (SI<Distance>.Quecto, "{0} qm", "1 quectometer", "{0} quectometers", "Quantity.Unit.Distance.Quectometers"),
-        new (SI<Distance>.Ronto, "{0} rm", "1 rontometer", "{0} rontometers", "Quantity.Unit.Distance.Rontometers"),
-        new (SI<Distance>.Yocto, "{0} ym", "1 yoctometer", "{0} yoctometers", "Quantity.Unit.Distance.Yoctometers"),
-        new (SI<Distance>.Zepto, "{0} zm", "1 zeptometer", "{0} zeptometers", "Quantity.Unit.Distance.Zeptometers"),
-        new (SI<Distance>.Atto, "{0} am", "1 attometer", "{0} attometers", "Quantity.Unit.Distance.Attometers"),
-        new (SI<Distance>.Femto, "{0} fm", "1 femtometer", "{0} femtometers", "Quantity.Unit.Distance.Femtometers"),
-        new (SI<Distance>.Pico, "{0} pm", "1 picometer", "{0} picometers", "Quantity.Unit.Distance.Picometers"),
-        new (SI<Distance>.Nano, "{0} nm", "1 nanometer", "{0} nanometers", "Quantity.Unit.Distance.Nanometers"),
-        new (SI<Distance>.Micro, "{0} µm", "1 micrometer", "{0} micrometers", "Quantity.Unit.Distance.Micrometers"),
-        new (SI<Distance>.Centi, "{0} cm", "1 centimeter", "{0} centimeters", "Quantity.Unit.Distance.Centimeters"),
-        new (SI<Distance>.Deci, "{0} dm", "1 decimeter", "{0} decimeters", "Quantity.Unit.Distance.Decimeters"),
-        new (SI<Distance>.Deca, "{0} dam", "1 decameter", "{0} decameters", "Quantity.Unit.Distance.Decameters"),
-        new (SI<Distance>.Hecto, "{0} hm", "1 hectometer", "{0} hectometers", "Quantity.Unit.Distance.Hectometers"),
-        new (SI<Distance>.Milli, "{0} mm", "1 millimeter", "{0} millimeters", "Quantity.Unit.Distance.Millimeters"),
-        new (SI<Distance>.Kilo, "{0} km", "1 kilometer", "{0} kilometers", "Quantity.Unit.Distance.Kilometers"),
-        new (SI<Distance>.Mega, "{0} Mm", "1 megameter", "{0} megameters", "Quantity.Unit.Distance.Megameters"),
-        new (SI<Distance>.Giga, "{0} Gm", "1 gigameter", "{0} gigameters", "Quantity.Unit.Distance.Gigameters"),
-        new (SI<Distance>.Tera, "{0} Tm", "1 terameter", "{0} terameters", "Quantity.Unit.Distance.Terameters"),
-        new (SI<Distance>.Peta, "{0} Pm", "1 petameter", "{0} petameters", "Quantity.Unit.Distance.Petameters"),
-        new (SI<Distance>.Exa, "{0} Em", "1 exameter", "{0} exameters", "Quantity.Unit.Distance.Exameters"),
-        new (SI<Distance>.Zetta, "{0} Zm", "1 zettameter", "{0} zettameters", "Quantity.Unit.Distance.Zettameters"),
-        new (SI<Distance>.Yotta, "{0} Ym", "1 yottameter", "{0} yottameters", "Quantity.Unit.Distance.Yottameters"),
-        new (SI<Distance>.Ronna, "{0} Rm", "1 ronnameter", "{0} ronnameters", "Quantity.Unit.Distance.Ronnameters"),
-        new (SI<Distance>.Quetta, "{0} Qm", "1 quettameter", "{0} quettameters", "Quantity.Unit.Distance.Quettameters")
+        new(Distance.AU, "{0} AU", "1 Astronomical Unit", "{0} Astronomical Units", "Quantity.Unit.Distance.AstronomicalUnits"),
+        new(Distance.Angstrom, "{0} Å", "1 ångström", "{0} ångströms", "Quantity.Unit.Distance.Ångströms"),
+        new(Distance.Foot, "{0} ft", "1 foot", "{0} feet", "Quantity.Unit.Distance.Feet"),
+        new(Distance.Inch, "{0} in", "1 inch", "{0} inches", "Quantity.Unit.Distance.Inches"),
+        new(Distance.Lightsecond, "{0} ls", "1 lightsecond", "{0} lightseconds", "Quantity.Unit.Distance.Lightseconds"),
+        new(Distance.Lightyear, "{0} ly", "1 lightyear", "{0} lightyears", "Quantity.Unit.Distance.Lightyears"),
+        new(Distance.Meter, "{0} m", "1 meter", "{0} meters", "Quantity.Unit.Distance.Meters"),
+        new(Distance.Mile, "{0} mi", "1 mile", "{0} miles", "Quantity.Unit.Distance.Miles"),
+        new(Distance.Parsec, "{0} pc", "1 parsec", "{0} parsecs", "Quantity.Unit.Distance.Parsecs"),
+        new(Distance.SolarRadius, "{0} R☉", "1 Solar radius", "{0} Solar radii", "Quantity.Unit.Distance.SolarRadii"),
+        new(Distance.Thou, "{0} th", "1 thou", "{0} thous", "Quantity.Unit.Distance.Thous"),
+        new(Distance.Yard, "{0} yd", "1 yard", "{0} yards", "Quantity.Unit.Distance.Yards"),
+        new(Distance.NauticalMile, "{0} NM", "1 nautical mile", "{0} nautical miles", "Quantity.Unit.Distance.NauticalMiles"),
+        new(Distance.Fathom, "{0} ftm", "1 fathom", "{0} fathoms", "Quantity.Unit.Distance.Fathoms"),
+        new(Distance.Chain, "{0} ch", "1 chain", "{0} chains", "Quantity.Unit.Distance.Chains"),
+        new(Distance.Rod, "{0} rd", "1 rod", "{0} rods", "Quantity.Unit.Distance.Rods"),
+        new(SI<Distance>.Quecto, "{0} qm", "1 quectometer", "{0} quectometers", "Quantity.Unit.Distance.Quectometers"),
+        new(SI<Distance>.Ronto, "{0} rm", "1 rontometer", "{0} rontometers", "Quantity.Unit.Distance.Rontometers"),
+        new(SI<Distance>.Yocto, "{0} ym", "1 yoctometer", "{0} yoctometers", "Quantity.Unit.Distance.Yoctometers"),
+        new(SI<Distance>.Zepto, "{0} zm", "1 zeptometer", "{0} zeptometers", "Quantity.Unit.Distance.Zeptometers"),
+        new(SI<Distance>.Atto, "{0} am", "1 attometer", "{0} attometers", "Quantity.Unit.Distance.Attometers"),
+        new(SI<Distance>.Femto, "{0} fm", "1 femtometer", "{0} femtometers", "Quantity.Unit.Distance.Femtometers"),
+        new(SI<Distance>.Pico, "{0} pm", "1 picometer", "{0} picometers", "Quantity.Unit.Distance.Picometers"),
+        new(SI<Distance>.Nano, "{0} nm", "1 nanometer", "{0} nanometers", "Quantity.Unit.Distance.Nanometers"),
+        new(SI<Distance>.Micro, "{0} µm", "1 micrometer", "{0} micrometers", "Quantity.Unit.Distance.Micrometers"),
+        new(SI<Distance>.Centi, "{0} cm", "1 centimeter", "{0} centimeters", "Quantity.Unit.Distance.Centimeters"),
+        new(SI<Distance>.Deci, "{0} dm", "1 decimeter", "{0} decimeters", "Quantity.Unit.Distance.Decimeters"),
+        new(SI<Distance>.Deca, "{0} dam", "1 decameter", "{0} decameters", "Quantity.Unit.Distance.Decameters"),
+        new(SI<Distance>.Hecto, "{0} hm", "1 hectometer", "{0} hectometers", "Quantity.Unit.Distance.Hectometers"),
+        new(SI<Distance>.Milli, "{0} mm", "1 millimeter", "{0} millimeters", "Quantity.Unit.Distance.Millimeters"),
+        new(SI<Distance>.Kilo, "{0} km", "1 kilometer", "{0} kilometers", "Quantity.Unit.Distance.Kilometers"),
+        new(SI<Distance>.Mega, "{0} Mm", "1 megameter", "{0} megameters", "Quantity.Unit.Distance.Megameters"),
+        new(SI<Distance>.Giga, "{0} Gm", "1 gigameter", "{0} gigameters", "Quantity.Unit.Distance.Gigameters"),
+        new(SI<Distance>.Tera, "{0} Tm", "1 terameter", "{0} terameters", "Quantity.Unit.Distance.Terameters"),
+        new(SI<Distance>.Peta, "{0} Pm", "1 petameter", "{0} petameters", "Quantity.Unit.Distance.Petameters"),
+        new(SI<Distance>.Exa, "{0} Em", "1 exameter", "{0} exameters", "Quantity.Unit.Distance.Exameters"),
+        new(SI<Distance>.Zetta, "{0} Zm", "1 zettameter", "{0} zettameters", "Quantity.Unit.Distance.Zettameters"),
+        new(SI<Distance>.Yotta, "{0} Ym", "1 yottameter", "{0} yottameters", "Quantity.Unit.Distance.Yottameters"),
+        new(SI<Distance>.Ronna, "{0} Rm", "1 ronnameter", "{0} ronnameters", "Quantity.Unit.Distance.Ronnameters"),
+        new(SI<Distance>.Quetta, "{0} Qm", "1 quettameter", "{0} quettameters", "Quantity.Unit.Distance.Quettameters")
     ];
 
-    internal static IEnumerable<object[]> DistanceShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            DistanceTestDataTuples.Select(distanceUnitArgs => new object[] {
-                distanceUnitArgs.unit, numValue, string.Format(distanceUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> DistanceLongNameSingularFormArgs
-    {
-        get => DistanceTestDataTuples.Select(distanceUnitArgs => new object[] {
-            distanceUnitArgs.unit, distanceUnitArgs.longNameSingle
-        });
-    }
-
-    internal static IEnumerable<object[]> DistanceLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            DistanceTestDataTuples.Select(distanceUnitArgs => new object[] {
-                distanceUnitArgs.unit, numValue, string.Format(distanceUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> DistancePredefinedCompoundFormatInfoArgs
-    {
-        get => new object[][]
-        {
-            [Distance.FeetInches, 0d, ""],
-            [Distance.FeetInches, .0254d, "1\""],
-            [Distance.FeetInches, .3048d, "1'"],
-            [Distance.FeetInches, .3302d, "1'1\""]
-        };
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for distance units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<DistanceUnitKeyTestData> DistanceUnitKeyArgs =>
-        DistanceTestDataTuples.Select(unitArgs => new DistanceUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(DistanceShortNameArgs))]
-    public void DistanceUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Distance> distanceUnit, double distanceValue, string expectedStr)
-    {
-        var distance = new Distance(distanceValue * distanceUnit.Ratio);
-        var resultStr = distance.FormatAs(distanceUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(DistanceLongNameSingularFormArgs))]
-    public void DistanceUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Distance> distanceUnit, string expectedStr)
-    {
-        var distance = new Distance(distanceUnit.Ratio);
-        var resultStr = distance.FormatAs(distanceUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(DistanceLongNamePluralFormArgs))]
-    public void DistanceUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Distance> distanceUnit, double distanceValue, string expectedStr)
-    {
-        var distance = new Distance(distanceValue * distanceUnit.Ratio);
-        var resultStr = distance.FormatAs(distanceUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-        [TestMethod]
-    [DynamicData(nameof(DistancePredefinedCompoundFormatInfoArgs))]
-    public void DistanceUnit_PredefinedQuantityCompoundFormatInfo_FormatsQuantityAsString(CompoundFormatInfo<Distance> distanceCompoundFormatInfo, double distanceValue, string expectedStr)
-    {
-        var distance = new Distance(distanceValue);
-        var resultStr = distance.FormatCompound(distanceCompoundFormatInfo);
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Distance unit will return the expected unit key.
-    /// </summary>
-    /// <param name="distanceUnit">The distance unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(DistanceUnitKeyArgs))]
-    public void GetDistanceUnitKey_ValidUnit_ReturnsUnitKey(Unit<Distance> distanceUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, distanceUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Distance>> CompoundFormatInfoDataTuples =>
+    [
+        new(Distance.FeetInches, 0d, ""),
+        new(Distance.FeetInches, .0254d, "1\""),
+        new(Distance.FeetInches, .3048d, "1'"),
+        new(Distance.FeetInches, .3302d, "1'1\""),
+    ];
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
@@ -7,7 +7,7 @@ namespace Elements.Quantity.Test.Quantities.Basic;
 
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class DistanceTests : BaseQuantityTests<DistanceTests, Distance>, IQuantityTestData<Distance>
+public class DistanceTests : BaseQuantityCompoundFormattedTests<DistanceTests, Distance>, IQuantityCompoundFormattedTestData<Distance>
 {
     /// <inheritdoc/>
     public static QuantityTestData<Distance>[] TestDataTuples =>

--- a/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
@@ -62,4 +62,7 @@ public class DistanceTests : BaseQuantityCompoundFormattedTests<DistanceTests, D
         new(Distance.FeetInches, .3048d, "1'"),
         new(Distance.FeetInches, .3302d, "1'1\""),
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Distance> ExpectedDefaultUnit => Distance.Meter;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/LuminanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/LuminanceTests.cs
@@ -1,158 +1,20 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using LuminanceTestData = QuantityTestData<Luminance>;
-using LuminanceUnitKeyTestData = (Unit<Luminance> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class LuminanceTests
+public class LuminanceTests : BaseQuantityTests<LuminanceTests, Luminance>, IQuantityTestData<Luminance>
 {
-    /// <summary>
-    /// An array of test data tuples representing different luminance units and their display formats. Each
-    /// element in the array contains information about a luminance unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static LuminanceTestData[] LuminanceTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Luminance>[] TestDataTuples =>
     [
-        new (Luminance.CandelaPerSquareMeter, "{0} cd/m²", "1 candela per square meter", "{0} candelas per square meter", "Quantity.Unit.Luminance.CandelasPerSquareMeter"),
-        new (Luminance.Nit, "{0} nt", "1 nit", "{0} nits", "Quantity.Unit.Luminance.Nits")
+        new(Luminance.CandelaPerSquareMeter, "{0} cd/m²", "1 candela per square meter", "{0} candelas per square meter", "Quantity.Unit.Luminance.CandelasPerSquareMeter"),
+        new(Luminance.Nit, "{0} nt", "1 nit", "{0} nits", "Quantity.Unit.Luminance.Nits")
     ];
 
-    /// <summary>
-    /// A collection of test data containing the luminance unit, the numeric value, and the expected
-    /// formatted short name.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> LuminanceShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            LuminanceTestDataTuples.Select(luminanceUnitArgs => new object[] {
-                luminanceUnitArgs.unit, numValue, string.Format(luminanceUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test data containing the luminance unit and the expected formatted long
-    /// name for singluar values.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> LuminanceLongNameSingularFormArgs
-    {
-        get => LuminanceTestDataTuples.Select(luminanceUnitArgs => new object[] {
-            luminanceUnitArgs.unit, luminanceUnitArgs.longNameSingle
-        });
-    }
-
-    /// <summary>
-    /// A collection of test data containing the luminance unit, the numeric value, and the expected
-    /// formatted long name for plural values.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> LuminanceLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            LuminanceTestDataTuples.Select(luminanceUnitArgs => new object[] {
-                luminanceUnitArgs.unit, numValue, string.Format(luminanceUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for luminance units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<LuminanceUnitKeyTestData> LuminanceUnitKeyArgs =>
-        LuminanceTestDataTuples.Select(unitArgs => new LuminanceUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    /// <summary>
-    /// Verifies that formatting a Luminance quantity using the specified unit and the default short name produces the
-    /// expected string representation.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the unit's default short name
-    /// when formatting a luminance value. It uses dynamic data to validate multiple unit and string
-    /// combinations.
-    /// </remarks>
-    /// <param name="luminanceUnit">The luminance unit to use when formatting the value.</param>
-    /// <param name="luminanceValue">The numeric value to be formatted.</param>
-    /// <param name="expectedStr">The expected string result when formatting the luminance value with the specified unit's default short name.</param>
-    [TestMethod]
-    [DynamicData(nameof(LuminanceShortNameArgs))]
-    public void LuminanceUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Luminance> luminanceUnit, double luminanceValue, string expectedStr)
-    {
-        var luminance = new Luminance(luminanceValue * luminanceUnit.Ratio);
-        var resultStr = luminance.FormatAs(luminanceUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that formatting a luminance value using the specified unit with the long name option produces
-    /// the expected singular long name string for singular values.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the singular form of the
-    /// unit's long name when formatting luminance values.
-    /// </remarks>
-    /// <param name="luminanceUnit">The luminance unit to use when formatting the value.</param>
-    /// <param name="expectedStr">The expected string result when formatting the luminance value with the long name option.</param>
-    [TestMethod]
-    [DynamicData(nameof(LuminanceLongNameSingularFormArgs))]
-    public void LuminanceUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Luminance> luminanceUnit, string expectedStr)
-    {
-        var luminance = new Luminance(luminanceUnit.Ratio);
-        var resultStr = luminance.FormatAs(luminanceUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that formatting a luminance value using the specified unit with the long name option produces
-    /// the expected plural long name string for plural values.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the  plural form of the
-    /// unit's long name when formatting luminance values.
-    /// </remarks>
-    /// <param name="luminanceUnit">The luminance unit to use when formatting the value.</param>
-    /// <param name="luminanceValue">The numeric value to be formatted.</param>
-    /// <param name="expectedStr">The expected string result when formatting the luminance value with the long name option.</param>
-    [TestMethod]
-    [DynamicData(nameof(LuminanceLongNamePluralFormArgs))]
-    public void LuminanceUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Luminance> luminanceUnit, double luminanceValue, string expectedStr)
-    {
-        var luminance = new Luminance(luminanceValue * luminanceUnit.Ratio);
-        var resultStr = luminance.FormatAs(luminanceUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Luminance unit will return the expected unit key.
-    /// </summary>
-    /// <param name="luminanceUnit">The luminance unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(LuminanceUnitKeyArgs))]
-    public void GetLuminanceUnitKey_ValidUnit_ReturnsUnitKey(Unit<Luminance> luminanceUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, luminanceUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Luminance>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/LuminanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/LuminanceTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
@@ -14,7 +13,4 @@ public class LuminanceTests : BaseQuantityTests<LuminanceTests, Luminance>, IQua
         new(Luminance.CandelaPerSquareMeter, "{0} cd/m²", "1 candela per square meter", "{0} candelas per square meter", "Quantity.Unit.Luminance.CandelasPerSquareMeter"),
         new(Luminance.Nit, "{0} nt", "1 nit", "{0} nits", "Quantity.Unit.Luminance.Nits")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Luminance>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/LuminanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/LuminanceTests.cs
@@ -13,4 +13,7 @@ public class LuminanceTests : BaseQuantityTests<LuminanceTests, Luminance>, IQua
         new(Luminance.CandelaPerSquareMeter, "{0} cd/m²", "1 candela per square meter", "{0} candelas per square meter", "Quantity.Unit.Luminance.CandelasPerSquareMeter"),
         new(Luminance.Nit, "{0} nt", "1 nit", "{0} nits", "Quantity.Unit.Luminance.Nits")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Luminance> ExpectedDefaultUnit => Luminance.CandelaPerSquareMeter;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/MassTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/MassTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
@@ -51,7 +50,4 @@ public class MassTests : BaseQuantityTests<MassTests, Mass>, IQuantityTestData<M
         new(SI<Mass>.Ronna, "{0} Rg", "1 ronnagram", "{0} ronnagrams", "Quantity.Unit.Mass.Ronnagrams"),
         new(SI<Mass>.Quetta, "{0} Qg", "1 quettagram", "{0} quettagrams", "Quantity.Unit.Mass.Quettagrams")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Mass>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/MassTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/MassTests.cs
@@ -1,134 +1,57 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using MassTestData = QuantityTestData<Mass>;
-using MassUnitKeyTestData = (Unit<Mass> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class MassTests
+public class MassTests : BaseQuantityTests<MassTests, Mass>, IQuantityTestData<Mass>
 {
-    internal static MassTestData[] MassTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Mass>[] TestDataTuples =>
     [
-        new (Mass.Gram, "{0} g", "1 gram", "{0} grams", "Quantity.Unit.Mass.Grams"),
+        new(Mass.Gram, "{0} g", "1 gram", "{0} grams", "Quantity.Unit.Mass.Grams"),
 #pragma warning disable CS0618 // Type or member is obsolete
-        new (Mass.Ton, "{0} t", "1 tonne", "{0} tonnes", "Quantity.Unit.Mass.Tonnes"),
+        new(Mass.Ton, "{0} t", "1 tonne", "{0} tonnes", "Quantity.Unit.Mass.Tonnes"),
 #pragma warning restore CS0618 // Type or member is obsolete
-        new (Mass.Tonne, "{0} t", "1 tonne", "{0} tonnes", "Quantity.Unit.Mass.Tonnes"),
-        new (Mass.Grain, "{0} gr", "1 grain", "{0} grains", "Quantity.Unit.Mass.Grains"),
-        new (Mass.Drachm, "{0} dr", "1 drachm", "{0} drachms", "Quantity.Unit.Mass.Drachms"),
-        new (Mass.Ounce, "{0} oz", "1 ounce", "{0} ounces", "Quantity.Unit.Mass.Ounces"),
-        new (Mass.Pound, "{0} lb", "1 pound", "{0} pounds", "Quantity.Unit.Mass.Pounds"),
-        new (Mass.Stone, "{0} st", "1 stone", "{0} stones", "Quantity.Unit.Mass.Stones"),
-        new (Mass.Quarter, "{0} qr", "1 quarter", "{0} quarters", "Quantity.Unit.Mass.Quarters"),
-        new (Mass.HundredWeight, "{0} cwt", "1 hundredweight", "{0} hundredweights", "Quantity.Unit.Mass.Hundredweights"),
-        new (Mass.ImperialTon, "{0} LT", "1 imperial ton", "{0} imperial tons", "Quantity.Unit.Mass.ImperialTons"),
-        new (Mass.ShortTon, "{0} tn", "1 ton", "{0} tons", "Quantity.Unit.Mass.Tons"),
-        new (Mass.Slug, "{0} slug", "1 slug", "{0} slugs", "Quantity.Unit.Mass.Slugs"),
-        new (SI<Mass>.Quecto, "{0} qg", "1 quectogram", "{0} quectograms", "Quantity.Unit.Mass.Quectograms"),
-        new (SI<Mass>.Ronto, "{0} rg", "1 rontogram", "{0} rontograms", "Quantity.Unit.Mass.Rontograms"),
-        new (SI<Mass>.Yocto, "{0} yg", "1 yoctogram", "{0} yoctograms", "Quantity.Unit.Mass.Yoctograms"),
-        new (SI<Mass>.Zepto, "{0} zg", "1 zeptogram", "{0} zeptograms", "Quantity.Unit.Mass.Zeptograms"),
-        new (SI<Mass>.Atto, "{0} ag", "1 attogram", "{0} attograms", "Quantity.Unit.Mass.Attograms"),
-        new (SI<Mass>.Femto, "{0} fg", "1 femtogram", "{0} femtograms", "Quantity.Unit.Mass.Femtograms"),
-        new (SI<Mass>.Pico, "{0} pg", "1 picogram", "{0} picograms", "Quantity.Unit.Mass.Picograms"),
-        new (SI<Mass>.Nano, "{0} ng", "1 nanogram", "{0} nanograms", "Quantity.Unit.Mass.Nanograms"),
-        new (SI<Mass>.Micro, "{0} µg", "1 microgram", "{0} micrograms", "Quantity.Unit.Mass.Micrograms"),
-        new (SI<Mass>.Centi, "{0} cg", "1 centigram", "{0} centigrams", "Quantity.Unit.Mass.Centigrams"),
-        new (SI<Mass>.Deci, "{0} dg", "1 decigram", "{0} decigrams", "Quantity.Unit.Mass.Decigrams"),
-        new (SI<Mass>.Deca, "{0} dag", "1 decagram", "{0} decagrams", "Quantity.Unit.Mass.Decagrams"),
-        new (SI<Mass>.Hecto, "{0} hg", "1 hectogram", "{0} hectograms", "Quantity.Unit.Mass.Hectograms"),
-        new (SI<Mass>.Milli, "{0} mg", "1 milligram", "{0} milligrams", "Quantity.Unit.Mass.Milligrams"),
-        new (SI<Mass>.Kilo, "{0} kg", "1 kilogram", "{0} kilograms", "Quantity.Unit.Mass.Kilograms"),
-        new (SI<Mass>.Mega, "{0} Mg", "1 megagram", "{0} megagrams", "Quantity.Unit.Mass.Megagrams"),
-        new (SI<Mass>.Giga, "{0} Gg", "1 gigagram", "{0} gigagrams", "Quantity.Unit.Mass.Gigagrams"),
-        new (SI<Mass>.Tera, "{0} Tg", "1 teragram", "{0} teragrams", "Quantity.Unit.Mass.Teragrams"),
-        new (SI<Mass>.Peta, "{0} Pg", "1 petagram", "{0} petagrams", "Quantity.Unit.Mass.Petagrams"),
-        new (SI<Mass>.Exa, "{0} Eg", "1 exagram", "{0} exagrams", "Quantity.Unit.Mass.Exagrams"),
-        new (SI<Mass>.Zetta, "{0} Zg", "1 zettagram", "{0} zettagrams", "Quantity.Unit.Mass.Zettagrams"),
-        new (SI<Mass>.Yotta, "{0} Yg", "1 yottagram", "{0} yottagrams", "Quantity.Unit.Mass.Yottagrams"),
-        new (SI<Mass>.Ronna, "{0} Rg", "1 ronnagram", "{0} ronnagrams", "Quantity.Unit.Mass.Ronnagrams"),
-        new (SI<Mass>.Quetta, "{0} Qg", "1 quettagram", "{0} quettagrams", "Quantity.Unit.Mass.Quettagrams")
+        new(Mass.Tonne, "{0} t", "1 tonne", "{0} tonnes", "Quantity.Unit.Mass.Tonnes"),
+        new(Mass.Grain, "{0} gr", "1 grain", "{0} grains", "Quantity.Unit.Mass.Grains"),
+        new(Mass.Drachm, "{0} dr", "1 drachm", "{0} drachms", "Quantity.Unit.Mass.Drachms"),
+        new(Mass.Ounce, "{0} oz", "1 ounce", "{0} ounces", "Quantity.Unit.Mass.Ounces"),
+        new(Mass.Pound, "{0} lb", "1 pound", "{0} pounds", "Quantity.Unit.Mass.Pounds"),
+        new(Mass.Stone, "{0} st", "1 stone", "{0} stones", "Quantity.Unit.Mass.Stones"),
+        new(Mass.Quarter, "{0} qr", "1 quarter", "{0} quarters", "Quantity.Unit.Mass.Quarters"),
+        new(Mass.HundredWeight, "{0} cwt", "1 hundredweight", "{0} hundredweights", "Quantity.Unit.Mass.Hundredweights"),
+        new(Mass.ImperialTon, "{0} LT", "1 imperial ton", "{0} imperial tons", "Quantity.Unit.Mass.ImperialTons"),
+        new(Mass.ShortTon, "{0} tn", "1 ton", "{0} tons", "Quantity.Unit.Mass.Tons"),
+        new(Mass.Slug, "{0} slug", "1 slug", "{0} slugs", "Quantity.Unit.Mass.Slugs"),
+        new(SI<Mass>.Quecto, "{0} qg", "1 quectogram", "{0} quectograms", "Quantity.Unit.Mass.Quectograms"),
+        new(SI<Mass>.Ronto, "{0} rg", "1 rontogram", "{0} rontograms", "Quantity.Unit.Mass.Rontograms"),
+        new(SI<Mass>.Yocto, "{0} yg", "1 yoctogram", "{0} yoctograms", "Quantity.Unit.Mass.Yoctograms"),
+        new(SI<Mass>.Zepto, "{0} zg", "1 zeptogram", "{0} zeptograms", "Quantity.Unit.Mass.Zeptograms"),
+        new(SI<Mass>.Atto, "{0} ag", "1 attogram", "{0} attograms", "Quantity.Unit.Mass.Attograms"),
+        new(SI<Mass>.Femto, "{0} fg", "1 femtogram", "{0} femtograms", "Quantity.Unit.Mass.Femtograms"),
+        new(SI<Mass>.Pico, "{0} pg", "1 picogram", "{0} picograms", "Quantity.Unit.Mass.Picograms"),
+        new(SI<Mass>.Nano, "{0} ng", "1 nanogram", "{0} nanograms", "Quantity.Unit.Mass.Nanograms"),
+        new(SI<Mass>.Micro, "{0} µg", "1 microgram", "{0} micrograms", "Quantity.Unit.Mass.Micrograms"),
+        new(SI<Mass>.Centi, "{0} cg", "1 centigram", "{0} centigrams", "Quantity.Unit.Mass.Centigrams"),
+        new(SI<Mass>.Deci, "{0} dg", "1 decigram", "{0} decigrams", "Quantity.Unit.Mass.Decigrams"),
+        new(SI<Mass>.Deca, "{0} dag", "1 decagram", "{0} decagrams", "Quantity.Unit.Mass.Decagrams"),
+        new(SI<Mass>.Hecto, "{0} hg", "1 hectogram", "{0} hectograms", "Quantity.Unit.Mass.Hectograms"),
+        new(SI<Mass>.Milli, "{0} mg", "1 milligram", "{0} milligrams", "Quantity.Unit.Mass.Milligrams"),
+        new(SI<Mass>.Kilo, "{0} kg", "1 kilogram", "{0} kilograms", "Quantity.Unit.Mass.Kilograms"),
+        new(SI<Mass>.Mega, "{0} Mg", "1 megagram", "{0} megagrams", "Quantity.Unit.Mass.Megagrams"),
+        new(SI<Mass>.Giga, "{0} Gg", "1 gigagram", "{0} gigagrams", "Quantity.Unit.Mass.Gigagrams"),
+        new(SI<Mass>.Tera, "{0} Tg", "1 teragram", "{0} teragrams", "Quantity.Unit.Mass.Teragrams"),
+        new(SI<Mass>.Peta, "{0} Pg", "1 petagram", "{0} petagrams", "Quantity.Unit.Mass.Petagrams"),
+        new(SI<Mass>.Exa, "{0} Eg", "1 exagram", "{0} exagrams", "Quantity.Unit.Mass.Exagrams"),
+        new(SI<Mass>.Zetta, "{0} Zg", "1 zettagram", "{0} zettagrams", "Quantity.Unit.Mass.Zettagrams"),
+        new(SI<Mass>.Yotta, "{0} Yg", "1 yottagram", "{0} yottagrams", "Quantity.Unit.Mass.Yottagrams"),
+        new(SI<Mass>.Ronna, "{0} Rg", "1 ronnagram", "{0} ronnagrams", "Quantity.Unit.Mass.Ronnagrams"),
+        new(SI<Mass>.Quetta, "{0} Qg", "1 quettagram", "{0} quettagrams", "Quantity.Unit.Mass.Quettagrams")
     ];
 
-    internal static IEnumerable<object[]> MassShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            MassTestDataTuples.Select(massUnitArgs => new object[] {
-                massUnitArgs.unit, numValue, string.Format(massUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> MassLongNameSingularFormArgs
-    {
-        get => MassTestDataTuples.Select(massUnitArgs => new object[] {
-            massUnitArgs.unit, massUnitArgs.longNameSingle
-        });
-    }
-
-    internal static IEnumerable<object[]> MassLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            MassTestDataTuples.Select(massUnitArgs => new object[] {
-                massUnitArgs.unit, numValue, string.Format(massUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for mass units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<MassUnitKeyTestData> MassUnitKeyArgs =>
-        MassTestDataTuples.Select(unitArgs => new MassUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(MassShortNameArgs))]
-    public void MassUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Mass> massUnit, double massValue, string expectedStr)
-    {
-        var mass = new Mass(massValue * massUnit.Ratio);
-        var resultStr = mass.FormatAs(massUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(MassLongNameSingularFormArgs))]
-    public void MassUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Mass> massUnit, string expectedStr)
-    {
-        var mass = new Mass(massUnit.Ratio);
-        var resultStr = mass.FormatAs(massUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(MassLongNamePluralFormArgs))]
-    public void MassUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Mass> massUnit, double massValue, string expectedStr)
-    {
-        var mass = new Mass(massValue * massUnit.Ratio);
-        var resultStr = mass.FormatAs(massUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Mass unit will return the expected unit key.
-    /// </summary>
-    /// <param name="massUnit">The mass unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(MassUnitKeyArgs))]
-    public void GetMassUnitKey_ValidUnit_ReturnsUnitKey(Unit<Mass> massUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, massUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Mass>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/MassTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/MassTests.cs
@@ -50,4 +50,7 @@ public class MassTests : BaseQuantityTests<MassTests, Mass>, IQuantityTestData<M
         new(SI<Mass>.Ronna, "{0} Rg", "1 ronnagram", "{0} ronnagrams", "Quantity.Unit.Mass.Ronnagrams"),
         new(SI<Mass>.Quetta, "{0} Qg", "1 quettagram", "{0} quettagrams", "Quantity.Unit.Mass.Quettagrams")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Mass> ExpectedDefaultUnit => SI<Mass>.Kilo;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/PressureTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/PressureTests.cs
@@ -1,186 +1,48 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using PressureTestData = QuantityTestData<Pressure>;
-using PressureUnitKeyTestData = (Unit<Pressure> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class PressureTests
+public class PressureTests : BaseQuantityTests<PressureTests, Pressure>, IQuantityTestData<Pressure>
 {
-    /// <summary>
-    /// An array of test data tuples representing different pressure units and their display formats. Each
-    /// element in the array contains information about a pressure unit, the short name, the singular
-    /// long name, and plural long name.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static PressureTestData[] PressureTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Pressure>[] TestDataTuples =>
     [
-        new (Pressure.Pascal, "{0} Pa", "1 pascal", "{0} pascals", "Quantity.Unit.Pressure.Pascals"),
-        new (Pressure.Bar, "{0} bar", "1 bar", "{0} bars", "Quantity.Unit.Pressure.Bars"),
-        new (Pressure.Atmosphere, "{0} atm", "1 standard atmosphere", "{0} standard atmospheres", "Quantity.Unit.Pressure.StandardAtmospheres"),
-        new (Pressure.Torr, "{0} Torr", "1 torr", "{0} torrs", "Quantity.Unit.Pressure.Torrs"),
-        new (Pressure.Millibar, "{0} mbar", "1 millibar", "{0} millibars", "Quantity.Unit.Pressure.Millibars"),
-        new (Pressure.PoundPerSquareInch, "{0} psi", "1 pound per square inch", "{0} pounds per square inch", "Quantity.Unit.Pressure.PoundsPerSquareInch"),
-        new (SI<Pressure>.Quecto, "{0} qPa", "1 quectopascal", "{0} quectopascals", "Quantity.Unit.Pressure.Quectopascals"),
-        new (SI<Pressure>.Ronto, "{0} rPa", "1 rontopascal", "{0} rontopascals", "Quantity.Unit.Pressure.Rontopascals"),
-        new (SI<Pressure>.Yocto, "{0} yPa", "1 yoctopascal", "{0} yoctopascals", "Quantity.Unit.Pressure.Yoctopascals"),
-        new (SI<Pressure>.Zepto, "{0} zPa", "1 zeptopascal", "{0} zeptopascals", "Quantity.Unit.Pressure.Zeptopascals"),
-        new (SI<Pressure>.Atto, "{0} aPa", "1 attopascal", "{0} attopascals", "Quantity.Unit.Pressure.Attopascals"),
-        new (SI<Pressure>.Femto, "{0} fPa", "1 femtopascal", "{0} femtopascals", "Quantity.Unit.Pressure.Femtopascals"),
-        new (SI<Pressure>.Pico, "{0} pPa", "1 picopascal", "{0} picopascals", "Quantity.Unit.Pressure.Picopascals"),
-        new (SI<Pressure>.Nano, "{0} nPa", "1 nanopascal", "{0} nanopascals", "Quantity.Unit.Pressure.Nanopascals"),
-        new (SI<Pressure>.Micro, "{0} µPa", "1 micropascal", "{0} micropascals", "Quantity.Unit.Pressure.Micropascals"),
-        new (SI<Pressure>.Milli, "{0} mPa", "1 millipascal", "{0} millipascals", "Quantity.Unit.Pressure.Millipascals"),
-        new (SI<Pressure>.Centi, "{0} cPa", "1 centipascal", "{0} centipascals", "Quantity.Unit.Pressure.Centipascals"),
-        new (SI<Pressure>.Deci, "{0} dPa", "1 decipascal", "{0} decipascals", "Quantity.Unit.Pressure.Decipascals"),
-        new (SI<Pressure>.Deca, "{0} daPa", "1 decapascal", "{0} decapascals", "Quantity.Unit.Pressure.Decapascals"),
-        new (SI<Pressure>.Hecto, "{0} hPa", "1 hectopascal", "{0} hectopascals", "Quantity.Unit.Pressure.Hectopascals"),
-        new (SI<Pressure>.Kilo, "{0} kPa", "1 kilopascal", "{0} kilopascals", "Quantity.Unit.Pressure.Kilopascals"),
-        new (SI<Pressure>.Mega, "{0} MPa", "1 megapascal", "{0} megapascals", "Quantity.Unit.Pressure.Megapascals"),
-        new (SI<Pressure>.Giga, "{0} GPa", "1 gigapascal", "{0} gigapascals", "Quantity.Unit.Pressure.Gigapascals"),
-        new (SI<Pressure>.Tera, "{0} TPa", "1 terapascal", "{0} terapascals", "Quantity.Unit.Pressure.Terapascals"),
-        new (SI<Pressure>.Peta, "{0} PPa", "1 petapascal", "{0} petapascals", "Quantity.Unit.Pressure.Petapascals"),
-        new (SI<Pressure>.Exa, "{0} EPa", "1 exapascal", "{0} exapascals", "Quantity.Unit.Pressure.Exapascals"),
-        new (SI<Pressure>.Zetta, "{0} ZPa", "1 zettapascal", "{0} zettapascals", "Quantity.Unit.Pressure.Zettapascals"),
-        new (SI<Pressure>.Yotta, "{0} YPa", "1 yottapascal", "{0} yottapascals", "Quantity.Unit.Pressure.Yottapascals"),
-        new (SI<Pressure>.Ronna, "{0} RPa", "1 ronnapascal", "{0} ronnapascals", "Quantity.Unit.Pressure.Ronnapascals"),
-        new (SI<Pressure>.Quetta, "{0} QPa", "1 quettapascal", "{0} quettapascals", "Quantity.Unit.Pressure.Quettapascals")
+        new(Pressure.Pascal, "{0} Pa", "1 pascal", "{0} pascals", "Quantity.Unit.Pressure.Pascals"),
+        new(Pressure.Bar, "{0} bar", "1 bar", "{0} bars", "Quantity.Unit.Pressure.Bars"),
+        new(Pressure.Atmosphere, "{0} atm", "1 standard atmosphere", "{0} standard atmospheres", "Quantity.Unit.Pressure.StandardAtmospheres"),
+        new(Pressure.Torr, "{0} Torr", "1 torr", "{0} torrs", "Quantity.Unit.Pressure.Torrs"),
+        new(Pressure.Millibar, "{0} mbar", "1 millibar", "{0} millibars", "Quantity.Unit.Pressure.Millibars"),
+        new(Pressure.PoundPerSquareInch, "{0} psi", "1 pound per square inch", "{0} pounds per square inch", "Quantity.Unit.Pressure.PoundsPerSquareInch"),
+        new(SI<Pressure>.Quecto, "{0} qPa", "1 quectopascal", "{0} quectopascals", "Quantity.Unit.Pressure.Quectopascals"),
+        new(SI<Pressure>.Ronto, "{0} rPa", "1 rontopascal", "{0} rontopascals", "Quantity.Unit.Pressure.Rontopascals"),
+        new(SI<Pressure>.Yocto, "{0} yPa", "1 yoctopascal", "{0} yoctopascals", "Quantity.Unit.Pressure.Yoctopascals"),
+        new(SI<Pressure>.Zepto, "{0} zPa", "1 zeptopascal", "{0} zeptopascals", "Quantity.Unit.Pressure.Zeptopascals"),
+        new(SI<Pressure>.Atto, "{0} aPa", "1 attopascal", "{0} attopascals", "Quantity.Unit.Pressure.Attopascals"),
+        new(SI<Pressure>.Femto, "{0} fPa", "1 femtopascal", "{0} femtopascals", "Quantity.Unit.Pressure.Femtopascals"),
+        new(SI<Pressure>.Pico, "{0} pPa", "1 picopascal", "{0} picopascals", "Quantity.Unit.Pressure.Picopascals"),
+        new(SI<Pressure>.Nano, "{0} nPa", "1 nanopascal", "{0} nanopascals", "Quantity.Unit.Pressure.Nanopascals"),
+        new(SI<Pressure>.Micro, "{0} µPa", "1 micropascal", "{0} micropascals", "Quantity.Unit.Pressure.Micropascals"),
+        new(SI<Pressure>.Milli, "{0} mPa", "1 millipascal", "{0} millipascals", "Quantity.Unit.Pressure.Millipascals"),
+        new(SI<Pressure>.Centi, "{0} cPa", "1 centipascal", "{0} centipascals", "Quantity.Unit.Pressure.Centipascals"),
+        new(SI<Pressure>.Deci, "{0} dPa", "1 decipascal", "{0} decipascals", "Quantity.Unit.Pressure.Decipascals"),
+        new(SI<Pressure>.Deca, "{0} daPa", "1 decapascal", "{0} decapascals", "Quantity.Unit.Pressure.Decapascals"),
+        new(SI<Pressure>.Hecto, "{0} hPa", "1 hectopascal", "{0} hectopascals", "Quantity.Unit.Pressure.Hectopascals"),
+        new(SI<Pressure>.Kilo, "{0} kPa", "1 kilopascal", "{0} kilopascals", "Quantity.Unit.Pressure.Kilopascals"),
+        new(SI<Pressure>.Mega, "{0} MPa", "1 megapascal", "{0} megapascals", "Quantity.Unit.Pressure.Megapascals"),
+        new(SI<Pressure>.Giga, "{0} GPa", "1 gigapascal", "{0} gigapascals", "Quantity.Unit.Pressure.Gigapascals"),
+        new(SI<Pressure>.Tera, "{0} TPa", "1 terapascal", "{0} terapascals", "Quantity.Unit.Pressure.Terapascals"),
+        new(SI<Pressure>.Peta, "{0} PPa", "1 petapascal", "{0} petapascals", "Quantity.Unit.Pressure.Petapascals"),
+        new(SI<Pressure>.Exa, "{0} EPa", "1 exapascal", "{0} exapascals", "Quantity.Unit.Pressure.Exapascals"),
+        new(SI<Pressure>.Zetta, "{0} ZPa", "1 zettapascal", "{0} zettapascals", "Quantity.Unit.Pressure.Zettapascals"),
+        new(SI<Pressure>.Yotta, "{0} YPa", "1 yottapascal", "{0} yottapascals", "Quantity.Unit.Pressure.Yottapascals"),
+        new(SI<Pressure>.Ronna, "{0} RPa", "1 ronnapascal", "{0} ronnapascals", "Quantity.Unit.Pressure.Ronnapascals"),
+        new(SI<Pressure>.Quetta, "{0} QPa", "1 quettapascal", "{0} quettapascals", "Quantity.Unit.Pressure.Quettapascals")
     ];
 
-    /// <summary>
-    /// A collection of test data containing the pressure unit, the numeric value, and the expected
-    /// formatted short name.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> PressureShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            PressureTestDataTuples.Select(pressureUnitArgs => new object[] {
-                pressureUnitArgs.unit, numValue, string.Format(pressureUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test data containing the pressure unit and the expected formatted long
-    /// name for singluar values.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> PressureLongNameSingularFormArgs
-    {
-        get => PressureTestDataTuples.Select(pressureUnitArgs => new object[] {
-            pressureUnitArgs.unit, pressureUnitArgs.longNameSingle
-        });
-    }
-
-    /// <summary>
-    /// A collection of test data containing the pressure unit, the numeric value, and the expected
-    /// formatted long name for plural values.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> PressureLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            PressureTestDataTuples.Select(pressureUnitArgs => new object[] {
-                pressureUnitArgs.unit, numValue, string.Format(pressureUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for pressure units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<PressureUnitKeyTestData> PressureUnitKeyArgs =>
-        PressureTestDataTuples.Select(unitArgs => new PressureUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    /// <summary>
-    /// Verifies that formatting a Pressure quantity using the specified unit and the default short name produces the
-    /// expected string representation.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the unit's default short name
-    /// when formatting a pressure value. It uses dynamic data to validate multiple unit and string
-    /// combinations.
-    /// </remarks>
-    /// <param name="pressureUnit">The pressure unit to use when formatting the value.</param>
-    /// <param name="pressureValue">The numeric value to be formatted.</param>
-    /// <param name="expectedStr">The expected string result when formatting the pressure value with the specified unit's default short name.</param>
-    [TestMethod]
-    [DynamicData(nameof(PressureShortNameArgs))]
-    public void PressureUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Pressure> pressureUnit, double pressureValue, string expectedStr)
-    {
-        var pressure = new Pressure(pressureValue * pressureUnit.Ratio);
-        var resultStr = pressure.FormatAs(pressureUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that formatting a pressure value using the specified unit with the long name option produces
-    /// the expected singular long name string for singular values.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the singular form of the
-    /// unit's long name when formatting pressure values.
-    /// </remarks>
-    /// <param name="pressureUnit">The pressure unit to use when formatting the value.</param>
-    /// <param name="expectedStr">The expected string result when formatting the pressure value with the long name option.</param>
-    [TestMethod]
-    [DynamicData(nameof(PressureLongNameSingularFormArgs))]
-    public void PressureUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Pressure> pressureUnit, string expectedStr)
-    {
-        var pressure = new Pressure(pressureUnit.Ratio);
-        var resultStr = pressure.FormatAs(pressureUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that formatting a pressure value using the specified unit with the long name option produces
-    /// the expected plural long name string for plural values.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the  plural form of the
-    /// unit's long name when formatting pressure values.
-    /// </remarks>
-    /// <param name="pressureUnit">The pressure unit to use when formatting the value.</param>
-    /// <param name="pressureValue">The numeric value to be formatted.</param>
-    /// <param name="expectedStr">The expected string result when formatting the pressure value with the long name option.</param>
-    [TestMethod]
-    [DynamicData(nameof(PressureLongNamePluralFormArgs))]
-    public void PressureUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Pressure> pressureUnit, double pressureValue, string expectedStr)
-    {
-        var pressure = new Pressure(pressureValue * pressureUnit.Ratio);
-        var resultStr = pressure.FormatAs(pressureUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Pressure unit will return the expected unit key.
-    /// </summary>
-    /// <param name="pressureUnit">The pressure unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(PressureUnitKeyArgs))]
-    public void GetPressureUnitKey_ValidUnit_ReturnsUnitKey(Unit<Pressure> pressureUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, pressureUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Pressure>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/PressureTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/PressureTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
@@ -42,7 +41,4 @@ public class PressureTests : BaseQuantityTests<PressureTests, Pressure>, IQuanti
         new(SI<Pressure>.Ronna, "{0} RPa", "1 ronnapascal", "{0} ronnapascals", "Quantity.Unit.Pressure.Ronnapascals"),
         new(SI<Pressure>.Quetta, "{0} QPa", "1 quettapascal", "{0} quettapascals", "Quantity.Unit.Pressure.Quettapascals")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Pressure>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/PressureTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/PressureTests.cs
@@ -41,4 +41,7 @@ public class PressureTests : BaseQuantityTests<PressureTests, Pressure>, IQuanti
         new(SI<Pressure>.Ronna, "{0} RPa", "1 ronnapascal", "{0} ronnapascals", "Quantity.Unit.Pressure.Ronnapascals"),
         new(SI<Pressure>.Quetta, "{0} QPa", "1 quettapascal", "{0} quettapascals", "Quantity.Unit.Pressure.Quettapascals")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Pressure> ExpectedDefaultUnit => Pressure.Pascal;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/RatioTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/RatioTests.cs
@@ -1,105 +1,20 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using RatioTestData = QuantityTestData<Ratio>;
-using RatioUnitKeyTestData = (Unit<Ratio> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class RatioTests
+public class RatioTests : BaseQuantityTests<RatioTests, Ratio>, IQuantityTestData<Ratio>
 {
-    /// <summary>
-    /// An array of test data tuples representing different ratio units and their display formats. Each
-    /// element in the array contains information about a ratio unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static RatioTestData[] RatioTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Ratio>[] TestDataTuples =>
     [
-        new (Ratio.RatioValue, "{0}", "1", "{0}", "Quantity.Unit.Ratio"),
-        new (Ratio.Percent, "{0} %", "1 percent", "{0} percent", "Quantity.Unit.Ratio.Percent")
+        new(Ratio.RatioValue, "{0}", "1", "{0}", "Quantity.Unit.Ratio"),
+        new(Ratio.Percent, "{0} %", "1 percent", "{0} percent", "Quantity.Unit.Ratio.Percent")
     ];
 
-    internal static IEnumerable<object[]> RatioShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            RatioTestDataTuples.Select(ratioUnitArgs => new object[] {
-                ratioUnitArgs.unit, numValue, string.Format(ratioUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> RatioLongNameSingularFormArgs
-    {
-        get => RatioTestDataTuples.Select(ratioUnitArgs => new object[] {
-            ratioUnitArgs.unit, ratioUnitArgs.longNameSingle
-        });
-    }
-
-    internal static IEnumerable<object[]> RatioLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            RatioTestDataTuples.Select(ratioUnitArgs => new object[] {
-                ratioUnitArgs.unit, numValue, string.Format(ratioUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for ratio units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<RatioUnitKeyTestData> RatioUnitKeyArgs =>
-        RatioTestDataTuples.Select(unitArgs => new RatioUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(RatioShortNameArgs))]
-    public void RatioUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Ratio> ratioUnit, double ratioValue, string expectedStr)
-    {
-        var ratio = new Ratio(ratioValue * ratioUnit.Ratio);
-        var resultStr = ratio.FormatAs(ratioUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(RatioLongNameSingularFormArgs))]
-    public void RatioUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Ratio> ratioUnit, string expectedStr)
-    {
-        var ratio = new Ratio(ratioUnit.Ratio);
-        var resultStr = ratio.FormatAs(ratioUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(RatioLongNamePluralFormArgs))]
-    public void RatioUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Ratio> ratioUnit, double ratioValue, string expectedStr)
-    {
-        var ratio = new Ratio(ratioValue * ratioUnit.Ratio);
-        var resultStr = ratio.FormatAs(ratioUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Ratio unit will return the expected unit key.
-    /// </summary>
-    /// <param name="ratioUnit">The ratio unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(RatioUnitKeyArgs))]
-    public void GetRatioUnitKey_ValidUnit_ReturnsUnitKey(Unit<Ratio> ratioUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, ratioUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Ratio>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/RatioTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/RatioTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
@@ -14,7 +13,4 @@ public class RatioTests : BaseQuantityTests<RatioTests, Ratio>, IQuantityTestDat
         new(Ratio.RatioValue, "{0}", "1", "{0}", "Quantity.Unit.Ratio"),
         new(Ratio.Percent, "{0} %", "1 percent", "{0} percent", "Quantity.Unit.Ratio.Percent")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Ratio>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/RatioTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/RatioTests.cs
@@ -13,4 +13,7 @@ public class RatioTests : BaseQuantityTests<RatioTests, Ratio>, IQuantityTestDat
         new(Ratio.RatioValue, "{0}", "1", "{0}", "Quantity.Unit.Ratio"),
         new(Ratio.Percent, "{0} %", "1 percent", "{0} percent", "Quantity.Unit.Ratio.Percent")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Ratio> ExpectedDefaultUnit => Ratio.RatioValue;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/TemperatureTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TemperatureTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
@@ -16,9 +15,6 @@ public class TemperatureTests : BaseQuantityTests<TemperatureTests, Temperature>
         new(Temperature.Fahrenheit, "{0} °F", "1 degree Fahrenheit", "{0} degrees Fahrenheit", "Quantity.Unit.Temperature.Fahrenheit"),
         new(Temperature.Rankine, "{0} °R", "1 degree Rankine", "{0} degrees Rankine", "Quantity.Unit.Temperature.Rankine")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Temperature>>? CompoundFormatInfoDataTuples => null;
 
     [DataRow(1, -272.15)]
     [DataRow(0, -273.15)]

--- a/Elements.Quantity.Tests/Quantities/Basic/TemperatureTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TemperatureTests.cs
@@ -1,26 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using TemperatureTestData = QuantityTestData<Temperature>;
-using TemperatureUnitKeyTestData = (Unit<Temperature> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class TemperatureTests
+public class TemperatureTests : BaseQuantityTests<TemperatureTests, Temperature>, IQuantityTestData<Temperature>
 {
-    /// <summary>
-    /// An array of test data tuples representing different temperature units and their display formats. Each
-    /// element in the array contains information about a temperature unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static TemperatureTestData[] TemperatureTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Temperature>[] TestDataTuples =>
     [
         new(Temperature.Kelvin, "{0} K", "1 Kelvin", "{0} Kelvins", "Quantity.Unit.Temperature.Kelvins"),
         new(Temperature.Celsius, "{0} °C", "1 degree Celsius", "{0} degrees Celsius", "Quantity.Unit.Temperature.Celsius"),
@@ -28,88 +17,8 @@ public class TemperatureTests
         new(Temperature.Rankine, "{0} °R", "1 degree Rankine", "{0} degrees Rankine", "Quantity.Unit.Temperature.Rankine")
     ];
 
-    internal static IEnumerable<object[]> TemperatureShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            TemperatureTestDataTuples.Select(temperatureUnitArgs => new object[]
-            {
-                temperatureUnitArgs.unit, numValue, string.Format(temperatureUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> TemperatureLongNameSingularFormArgs
-    {
-        get => TemperatureTestDataTuples.Select(temperatureUnitArgs => new object[]
-        {
-            temperatureUnitArgs.unit, temperatureUnitArgs.longNameSingle
-        });
-    }
-
-    internal static IEnumerable<object[]> TemperatureLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            TemperatureTestDataTuples.Select(temperatureUnitArgs => new object[]
-            {
-                temperatureUnitArgs.unit, numValue, string.Format(temperatureUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for temperature units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<TemperatureUnitKeyTestData> TemperatureUnitKeyArgs =>
-        TemperatureTestDataTuples.Select(unitArgs => new TemperatureUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(TemperatureShortNameArgs))]
-    public void TemperatureUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(
-        Unit<Temperature> temperatureUnit, double temperatureValue, string expectedStr)
-    {
-        var temperature = temperatureUnit.ConvertFrom(temperatureValue);
-        var resultStr = temperature.FormatAs(temperatureUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(TemperatureLongNameSingularFormArgs))]
-    public void TemperatureUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(
-        Unit<Temperature> temperatureUnit, string expectedStr)
-    {
-        var temperature = temperatureUnit.ConvertFrom(1);
-        var resultStr = temperature.FormatAs(temperatureUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(TemperatureLongNamePluralFormArgs))]
-    public void TemperatureUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(
-        Unit<Temperature> temperatureUnit, double temperatureValue, string expectedStr)
-    {
-        var temperature = temperatureUnit.ConvertFrom(temperatureValue);
-        var resultStr = temperature.FormatAs(temperatureUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Temperature unit will return the expected unit key.
-    /// </summary>
-    /// <param name="temperatureUnit">The temperature unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(TemperatureUnitKeyArgs))]
-    public void GetTemperatureUnitKey_ValidUnit_ReturnsUnitKey(Unit<Temperature> temperatureUnit,
-        string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, temperatureUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Temperature>>? CompoundFormatInfoDataTuples => null;
 
     [DataRow(1, -272.15)]
     [DataRow(0, -273.15)]

--- a/Elements.Quantity.Tests/Quantities/Basic/TemperatureTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TemperatureTests.cs
@@ -16,6 +16,9 @@ public class TemperatureTests : BaseQuantityTests<TemperatureTests, Temperature>
         new(Temperature.Rankine, "{0} °R", "1 degree Rankine", "{0} degrees Rankine", "Quantity.Unit.Temperature.Rankine")
     ];
 
+    /// <inheritdoc/>
+    public sealed override Unit<Temperature> ExpectedDefaultUnit => Temperature.Kelvin;
+
     [DataRow(1, -272.15)]
     [DataRow(0, -273.15)]
     [DataRow(373.1, 100)]//Boiling point of water

--- a/Elements.Quantity.Tests/Quantities/Basic/TimeTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TimeTests.cs
@@ -7,7 +7,7 @@ namespace Elements.Quantity.Test.Quantities.Basic;
 
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class TimeTests : BaseQuantityTests<TimeTests, Time>, IQuantityTestData<Time>
+public class TimeTests : BaseQuantityCompoundFormattedTests<TimeTests, Time>, IQuantityCompoundFormattedTestData<Time>
 {
     /// <inheritdoc/>
     public static QuantityTestData<Time>[] TestDataTuples =>
@@ -20,7 +20,7 @@ public class TimeTests : BaseQuantityTests<TimeTests, Time>, IQuantityTestData<T
     ];
 
     /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Time>>? CompoundFormatInfoDataTuples => [
+    public static IEnumerable<QuantityFormatTestData<Time>> CompoundFormatInfoDataTuples => [
         new(Time.MinuteSecond, 0d, "00:00"),
         new(Time.MinuteSecond, 30d, "00:30"),
         new(Time.MinuteSecond, 150d, "02:30"),

--- a/Elements.Quantity.Tests/Quantities/Basic/TimeTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TimeTests.cs
@@ -1,176 +1,76 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using TimeTestData = QuantityTestData<Time>;
-using TimeUnitKeyTestData = (Unit<Time> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class TimeTests
+public class TimeTests : BaseQuantityTests<TimeTests, Time>, IQuantityTestData<Time>
 {
-    /// <summary>
-    /// An array of test data tuples representing different time units and their display formats. Each
-    /// element in the array contains information about a time unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static TimeTestData[] TimeTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Time>[] TestDataTuples =>
     [
-        new (Time.Millisecond, "{0} ms", "1 millisecond", "{0} milliseconds", "Quantity.Unit.Time.Milliseconds"),
-        new (Time.Second, "{0} s", "1 second", "{0} seconds", "Quantity.Unit.Time.Seconds"),
-        new (Time.Minute, "{0} m", "1 minute", "{0} minutes", "Quantity.Unit.Time.Minutes"),
-        new (Time.Hour, "{0} h", "1 hour", "{0} hours", "Quantity.Unit.Time.Hours"),
-        new (Time.Day, "{0} d", "1 day", "{0} days", "Quantity.Unit.Time.Days")
+        new(Time.Millisecond, "{0} ms", "1 millisecond", "{0} milliseconds", "Quantity.Unit.Time.Milliseconds"),
+        new(Time.Second, "{0} s", "1 second", "{0} seconds", "Quantity.Unit.Time.Seconds"),
+        new(Time.Minute, "{0} m", "1 minute", "{0} minutes", "Quantity.Unit.Time.Minutes"),
+        new(Time.Hour, "{0} h", "1 hour", "{0} hours", "Quantity.Unit.Time.Hours"),
+        new(Time.Day, "{0} d", "1 day", "{0} days", "Quantity.Unit.Time.Days")
     ];
 
-    internal static IEnumerable<object[]> TimeShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            TimeTestDataTuples.Select(timeUnitArgs => new object[] {
-                timeUnitArgs.unit, numValue, string.Format(timeUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> TimeLongNameSingularFormArgs
-    {
-        get => TimeTestDataTuples.Select(timeUnitArgs => new object[] {
-            timeUnitArgs.unit, timeUnitArgs.longNameSingle
-        });
-    }
-
-    internal static IEnumerable<object[]> TimeLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            TimeTestDataTuples.Select(timeUnitArgs => new object[] {
-                timeUnitArgs.unit, numValue, string.Format(timeUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> TimePredefinedCompoundFormatInfoArgs
-    {
-        get => new object[][]
-        {
-            [Time.MinuteSecond, 0d, "00:00"],
-            [Time.MinuteSecond, 30d, "00:30"],
-            [Time.MinuteSecond, 150d, "02:30"],
-            [Time.MinuteSecond, 150.4d, "02:30"],
-            [Time.HourMinuteSecond, 150d, "0:02:30"],
-            [Time.HourMinuteSecond, 3750d, "1:02:30"],
-            [Time.HourMinuteSecond, 3750.4d, "1:02:30"],
-            [Time.HourMinuteSecond, 360150d, "100:02:30"],
-            [Time.HourMinuteSecond_Trimmed, 0d, "00:00"],
-            [Time.HourMinuteSecond_Trimmed, 150d, "02:30"],
-            [Time.HourMinuteSecond_Trimmed, 3750d, "1:02:30"],
-            [Time.DayHourMinuteSecond_Long, 0d, "0 seconds"],
-            [Time.DayHourMinuteSecond_Long, 1d, "1 second"],
-            [Time.DayHourMinuteSecond_Long, 10d, "10 seconds"],
-            [Time.DayHourMinuteSecond_Long, 60d, "1 minute 0 seconds"],
-            [Time.DayHourMinuteSecond_Long, 61.2d, "1 minute 1 second"],
-            [Time.DayHourMinuteSecond_Long, 122.2d, "2 minutes 2 seconds"],
-            [Time.DayHourMinuteSecond_Long, 3661.2d, "1 hour 1 minute 1 second"],
-            [Time.DayHourMinuteSecond_Long, 7322.2d, "2 hours 2 minutes 2 seconds"],
-            [Time.DayHourMinuteSecond_Long, 90061.4d, "1 day 1 hour 1 minute 1 second"],
-            [Time.DayHourMinuteSecond_Long, 180122.4d, "2 days 2 hours 2 minutes 2 seconds"],
-            [Time.DayHourMinute_Long, 1d, "0 minutes"],
-            [Time.DayHourMinute_Long, 10d, "0 minutes"],
-            [Time.DayHourMinute_Long, 60d, "1 minute"],
-            [Time.DayHourMinute_Long, 61.2d, "1 minute"],
-            [Time.DayHourMinute_Long, 122.2d, "2 minutes"],
-            [Time.DayHourMinute_Long, 3661.2d, "1 hour 1 minute"],
-            [Time.DayHourMinute_Long, 7322.2d, "2 hours 2 minutes"],
-            [Time.DayHourMinute_Long, 90061.4d, "1 day 1 hour 1 minute"],
-            [Time.DayHourMinute_Long, 180122.4d, "2 days 2 hours 2 minutes"],
-            [Time.DayHourMinuteSecond_Trimmed, 0d, "00:00"],
-            [Time.DayHourMinuteSecond_Trimmed, 150d, "02:30"],
-            [Time.DayHourMinuteSecond_Trimmed, 3750d, "1:02:30"],
-            [Time.DayHourMinuteSecond_Trimmed, 90150.4d, "1day:1:02:30"],
-            [Time.DayHourMinuteSecond_Trimmed, 176550.6d, "2day:1:02:30"],
-            [Time.HourMinuteSecond_Symbol, 0d, "00 s"],
-            [Time.HourMinuteSecond_Symbol, 1d, "01 s"],
-            [Time.HourMinuteSecond_Symbol, 120d, "2 m 00 s"],
-            [Time.HourMinuteSecond_Symbol, 150d, "2 m 30 s"],
-            [Time.HourMinuteSecond_Symbol, 3720d, "1 h 2 m 00 s"],
-            [Time.HourMinuteSecond_Symbol, 3750d, "1 h 2 m 30 s"],
-            [Time.StopWatch, 0d, "00:00:00"],
-            [Time.StopWatch, 0.5d, "00:00:500"],
-            [Time.StopWatch, 0.55d, "00:00:550"],
-            [Time.StopWatch, 0.555d, "00:00:555"],
-            [Time.StopWatch, 1d, "00:01:00"],
-            [Time.StopWatch, 1.5d, "00:01:500"],
-            [Time.StopWatch, 60d, "01:00:00"],
-            [Time.StopWatch, 60.5002d, "01:00:500"],
-            [Time.StopWatch, 3600d, "1:00:00:00"],
-            [Time.StopWatch, 3600.5002d, "1:00:00:500"]
-        };
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for time units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<TimeUnitKeyTestData> TimeUnitKeyArgs =>
-        TimeTestDataTuples.Select(unitArgs => new TimeUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(TimeShortNameArgs))]
-    public void TimeUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Time> timeUnit, double timeValue, string expectedStr)
-    {
-        var time = new Time(timeValue * timeUnit.Ratio);
-        var resultStr = time.FormatAs(timeUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(TimeLongNameSingularFormArgs))]
-    public void TimeUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Time> timeUnit, string expectedStr)
-    {
-        var time = new Time(timeUnit.Ratio);
-        var resultStr = time.FormatAs(timeUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(TimeLongNamePluralFormArgs))]
-    public void TimeUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Time> timeUnit, double timeValue, string expectedStr)
-    {
-        var time = new Time(timeValue * timeUnit.Ratio);
-        var resultStr = time.FormatAs(timeUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(TimePredefinedCompoundFormatInfoArgs))]
-    public void TimeUnit_PredefinedQuantityCompoundFormatInfo_FormatsQuantityAsString(CompoundFormatInfo<Time> timeCompoundFormatInfo, double timeValue, string expectedStr)
-    {
-        var time = new Time(timeValue);
-        var resultStr = time.FormatCompound(timeCompoundFormatInfo);
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Time unit will return the expected unit key.
-    /// </summary>
-    /// <param name="timeUnit">The time unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(TimeUnitKeyArgs))]
-    public void GetTimeUnitKey_ValidUnit_ReturnsUnitKey(Unit<Time> timeUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, timeUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Time>>? CompoundFormatInfoDataTuples => [
+        new(Time.MinuteSecond, 0d, "00:00"),
+        new(Time.MinuteSecond, 30d, "00:30"),
+        new(Time.MinuteSecond, 150d, "02:30"),
+        new(Time.MinuteSecond, 150.4d, "02:30"),
+        new(Time.HourMinuteSecond, 150d, "0:02:30"),
+        new(Time.HourMinuteSecond, 3750d, "1:02:30"),
+        new(Time.HourMinuteSecond, 3750.4d, "1:02:30"),
+        new(Time.HourMinuteSecond, 360150d, "100:02:30"),
+        new(Time.HourMinuteSecond_Trimmed, 0d, "00:00"),
+        new(Time.HourMinuteSecond_Trimmed, 150d, "02:30"),
+        new(Time.HourMinuteSecond_Trimmed, 3750d, "1:02:30"),
+        new(Time.DayHourMinuteSecond_Long, 0d, "0 seconds"),
+        new(Time.DayHourMinuteSecond_Long, 1d, "1 second"),
+        new(Time.DayHourMinuteSecond_Long, 10d, "10 seconds"),
+        new(Time.DayHourMinuteSecond_Long, 60d, "1 minute 0 seconds"),
+        new(Time.DayHourMinuteSecond_Long, 61.2d, "1 minute 1 second"),
+        new(Time.DayHourMinuteSecond_Long, 122.2d, "2 minutes 2 seconds"),
+        new(Time.DayHourMinuteSecond_Long, 3661.2d, "1 hour 1 minute 1 second"),
+        new(Time.DayHourMinuteSecond_Long, 7322.2d, "2 hours 2 minutes 2 seconds"),
+        new(Time.DayHourMinuteSecond_Long, 90061.4d, "1 day 1 hour 1 minute 1 second"),
+        new(Time.DayHourMinuteSecond_Long, 180122.4d, "2 days 2 hours 2 minutes 2 seconds"),
+        new(Time.DayHourMinute_Long, 1d, "0 minutes"),
+        new(Time.DayHourMinute_Long, 10d, "0 minutes"),
+        new(Time.DayHourMinute_Long, 60d, "1 minute"),
+        new(Time.DayHourMinute_Long, 61.2d, "1 minute"),
+        new(Time.DayHourMinute_Long, 122.2d, "2 minutes"),
+        new(Time.DayHourMinute_Long, 3661.2d, "1 hour 1 minute"),
+        new(Time.DayHourMinute_Long, 7322.2d, "2 hours 2 minutes"),
+        new(Time.DayHourMinute_Long, 90061.4d, "1 day 1 hour 1 minute"),
+        new(Time.DayHourMinute_Long, 180122.4d, "2 days 2 hours 2 minutes"),
+        new(Time.DayHourMinuteSecond_Trimmed, 0d, "00:00"),
+        new(Time.DayHourMinuteSecond_Trimmed, 150d, "02:30"),
+        new(Time.DayHourMinuteSecond_Trimmed, 3750d, "1:02:30"),
+        new(Time.DayHourMinuteSecond_Trimmed, 90150.4d, "1day:1:02:30"),
+        new(Time.DayHourMinuteSecond_Trimmed, 176550.6d, "2day:1:02:30"),
+        new(Time.HourMinuteSecond_Symbol, 0d, "00 s"),
+        new(Time.HourMinuteSecond_Symbol, 1d, "01 s"),
+        new(Time.HourMinuteSecond_Symbol, 120d, "2 m 00 s"),
+        new(Time.HourMinuteSecond_Symbol, 150d, "2 m 30 s"),
+        new(Time.HourMinuteSecond_Symbol, 3720d, "1 h 2 m 00 s"),
+        new(Time.HourMinuteSecond_Symbol, 3750d, "1 h 2 m 30 s"),
+        new(Time.StopWatch, 0d, "00:00:00"),
+        new(Time.StopWatch, 0.5d, "00:00:500"),
+        new(Time.StopWatch, 0.55d, "00:00:550"),
+        new(Time.StopWatch, 0.555d, "00:00:555"),
+        new(Time.StopWatch, 1d, "00:01:00"),
+        new(Time.StopWatch, 1.5d, "00:01:500"),
+        new(Time.StopWatch, 60d, "01:00:00"),
+        new(Time.StopWatch, 60.5002d, "01:00:500"),
+        new(Time.StopWatch, 3600d, "1:00:00:00"),
+        new(Time.StopWatch, 3600.5002d, "1:00:00:500"),
+    ];
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/TimeTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TimeTests.cs
@@ -20,6 +20,9 @@ public class TimeTests : BaseQuantityCompoundFormattedTests<TimeTests, Time>, IQ
     ];
 
     /// <inheritdoc/>
+    public sealed override Unit<Time> ExpectedDefaultUnit => Time.Second;
+
+    /// <inheritdoc/>
     public static IEnumerable<QuantityFormatTestData<Time>> CompoundFormatInfoDataTuples => [
         new(Time.MinuteSecond, 0d, "00:00"),
         new(Time.MinuteSecond, 30d, "00:30"),

--- a/Elements.Quantity.Tests/Quantities/Basic/TorqueTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TorqueTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
@@ -14,7 +13,4 @@ public class TorqueTests : BaseQuantityTests<TorqueTests, Torque>, IQuantityTest
         new(Torque.NewtonMeter, "{0} N m", "1 newton meter", "{0} newton meters", "Quantity.Unit.Torque.NewtonMeters"),
         new(Torque.PoundFoot, "{0} lb·ft", "1 pound-foot", "{0} pound-feet", "Quantity.Unit.Torque.Pound-feet")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Torque>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/TorqueTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TorqueTests.cs
@@ -1,158 +1,20 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using TorqueTestData = QuantityTestData<Torque>;
-using TorqueUnitKeyTestData = (Unit<Torque> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class TorqueTests
+public class TorqueTests : BaseQuantityTests<TorqueTests, Torque>, IQuantityTestData<Torque>
 {
-    /// <summary>
-    /// An array of test data tuples representing different torque units and their display formats. Each
-    /// element in the array contains information about a torque unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static TorqueTestData[] TorqueTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Torque>[] TestDataTuples =>
     [
-        new (Torque.NewtonMeter, "{0} N m", "1 newton meter", "{0} newton meters", "Quantity.Unit.Torque.NewtonMeters"),
-        new (Torque.PoundFoot, "{0} lb·ft", "1 pound-foot", "{0} pound-feet", "Quantity.Unit.Torque.Pound-feet")
+        new(Torque.NewtonMeter, "{0} N m", "1 newton meter", "{0} newton meters", "Quantity.Unit.Torque.NewtonMeters"),
+        new(Torque.PoundFoot, "{0} lb·ft", "1 pound-foot", "{0} pound-feet", "Quantity.Unit.Torque.Pound-feet")
     ];
 
-    /// <summary>
-    /// A collection of test data containing the torque unit, the numeric value, and the expected
-    /// formatted short name.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> TorqueShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            TorqueTestDataTuples.Select(torqueUnitArgs => new object[] {
-                torqueUnitArgs.unit, numValue, string.Format(torqueUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test data containing the torque unit and the expected formatted long
-    /// name for singluar values.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> TorqueLongNameSingularFormArgs
-    {
-        get => TorqueTestDataTuples.Select(torqueUnitArgs => new object[] {
-            torqueUnitArgs.unit, torqueUnitArgs.longNameSingle
-        });
-    }
-
-    /// <summary>
-    /// A collection of test data containing the torque unit, the numeric value, and the expected
-    /// formatted long name for plural values.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<object[]> TorqueLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            TorqueTestDataTuples.Select(torqueUnitArgs => new object[] {
-                torqueUnitArgs.unit, numValue, string.Format(torqueUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for torque units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<TorqueUnitKeyTestData> TorqueUnitKeyArgs =>
-        TorqueTestDataTuples.Select(unitArgs => new TorqueUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    /// <summary>
-    /// Verifies that formatting a Torque quantity using the specified unit and the default short name produces the
-    /// expected string representation.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the unit's default short name
-    /// when formatting a torque value. It uses dynamic data to validate multiple unit and string
-    /// combinations.
-    /// </remarks>
-    /// <param name="torqueUnit">The torque unit to use when formatting the value.</param>
-    /// <param name="torqueValue">The numeric value to be formatted.</param>
-    /// <param name="expectedStr">The expected string result when formatting the torque value with the specified unit's default short name.</param>
-    [TestMethod]
-    [DynamicData(nameof(TorqueShortNameArgs))]
-    public void TorqueUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Torque> torqueUnit, double torqueValue, string expectedStr)
-    {
-        var torque = new Torque(torqueValue * torqueUnit.Ratio);
-        var resultStr = torque.FormatAs(torqueUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that formatting a torque value using the specified unit with the long name option produces
-    /// the expected singular long name string for singular values.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the singular form of the
-    /// unit's long name when formatting torque values.
-    /// </remarks>
-    /// <param name="torqueUnit">The torque unit to use when formatting the value.</param>
-    /// <param name="expectedStr">The expected string result when formatting the torque value with the long name option.</param>
-    [TestMethod]
-    [DynamicData(nameof(TorqueLongNameSingularFormArgs))]
-    public void TorqueUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Torque> torqueUnit, string expectedStr)
-    {
-        var torque = new Torque(torqueUnit.Ratio);
-        var resultStr = torque.FormatAs(torqueUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that formatting a torque value using the specified unit with the long name option produces
-    /// the expected plural long name string for plural values.
-    /// </summary>
-    /// <remarks>
-    /// This test ensures that the FormatAs method correctly applies the  plural form of the
-    /// unit's long name when formatting torque values.
-    /// </remarks>
-    /// <param name="torqueUnit">The torque unit to use when formatting the value.</param>
-    /// <param name="torqueValue">The numeric value to be formatted.</param>
-    /// <param name="expectedStr">The expected string result when formatting the torque value with the long name option.</param>
-    [TestMethod]
-    [DynamicData(nameof(TorqueLongNamePluralFormArgs))]
-    public void TorqueUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Torque> torqueUnit, double torqueValue, string expectedStr)
-    {
-        var torque = new Torque(torqueValue * torqueUnit.Ratio);
-        var resultStr = torque.FormatAs(torqueUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Torque unit will return the expected unit key.
-    /// </summary>
-    /// <param name="torqueUnit">The torque unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(TorqueUnitKeyArgs))]
-    public void GetTorqueUnitKey_ValidUnit_ReturnsUnitKey(Unit<Torque> torqueUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, torqueUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Torque>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/TorqueTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/TorqueTests.cs
@@ -13,4 +13,7 @@ public class TorqueTests : BaseQuantityTests<TorqueTests, Torque>, IQuantityTest
         new(Torque.NewtonMeter, "{0} N m", "1 newton meter", "{0} newton meters", "Quantity.Unit.Torque.NewtonMeters"),
         new(Torque.PoundFoot, "{0} lb·ft", "1 pound-foot", "{0} pound-feet", "Quantity.Unit.Torque.Pound-feet")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Torque> ExpectedDefaultUnit => Torque.NewtonMeter;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/VelocityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/VelocityTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 
@@ -18,7 +17,4 @@ public class VelocityTests : BaseQuantityTests<VelocityTests, Velocity>, IQuanti
         new(Velocity.FeetPerSecond, "{0} ft/s", "1 foot per second", "{0} feet per second", "Quantity.Unit.Velocity.FeetPerSecond"),
         new(Velocity.Knots, "{0} kn", "1 knot", "{0} knots", "Quantity.Unit.Velocity.Knots")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Velocity>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/VelocityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/VelocityTests.cs
@@ -1,108 +1,24 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Basic;
 
-using VelocityTestData = QuantityTestData<Velocity>;
-using VelocityUnitKeyTestData = (Unit<Velocity> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class VelocityTests
+public class VelocityTests : BaseQuantityTests<VelocityTests, Velocity>, IQuantityTestData<Velocity>
 {
-    /// <summary>
-    /// An array of test data tuples representing different velocity units and their display formats. Each
-    /// element in the array contains information about a velocity unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static VelocityTestData[] VelocityTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Velocity>[] TestDataTuples =>
     [
-        new (Velocity.MetersPerSecond, "{0} m/s", "1 meter per second", "{0} meters per second", "Quantity.Unit.Velocity.MetersPerSecond"),
-        new (Velocity.KilometersPerHour, "{0} km/h", "1 kilometer per hour", "{0} kilometers per hour", "Quantity.Unit.Velocity.KilometersPerHour"),
-        new (Velocity.MilesPerHour, "{0} mph", "1 mile per hour", "{0} miles per hour", "Quantity.Unit.Velocity.MilesPerHour"),
-        new (Velocity.FeetPerSecond, "{0} ft/s", "1 foot per second", "{0} feet per second", "Quantity.Unit.Velocity.FeetPerSecond"),
-        new (Velocity.Knots, "{0} kn", "1 knot", "{0} knots", "Quantity.Unit.Velocity.Knots")
+        new(Velocity.MetersPerSecond, "{0} m/s", "1 meter per second", "{0} meters per second", "Quantity.Unit.Velocity.MetersPerSecond"),
+        new(Velocity.KilometersPerHour, "{0} km/h", "1 kilometer per hour", "{0} kilometers per hour", "Quantity.Unit.Velocity.KilometersPerHour"),
+        new(Velocity.MilesPerHour, "{0} mph", "1 mile per hour", "{0} miles per hour", "Quantity.Unit.Velocity.MilesPerHour"),
+        new(Velocity.FeetPerSecond, "{0} ft/s", "1 foot per second", "{0} feet per second", "Quantity.Unit.Velocity.FeetPerSecond"),
+        new(Velocity.Knots, "{0} kn", "1 knot", "{0} knots", "Quantity.Unit.Velocity.Knots")
     ];
 
-    internal static IEnumerable<object[]> VelocityShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            VelocityTestDataTuples.Select(velocityUnitArgs => new object[] {
-                velocityUnitArgs.unit, numValue, string.Format(velocityUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> VelocityLongNameSingularFormArgs
-    {
-        get => VelocityTestDataTuples.Select(velocityUnitArgs => new object[] {
-            velocityUnitArgs.unit, velocityUnitArgs.longNameSingle
-        });
-    }
-
-    internal static IEnumerable<object[]> VelocityLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            VelocityTestDataTuples.Select(velocityUnitArgs => new object[] {
-                velocityUnitArgs.unit, numValue, string.Format(velocityUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for velocity units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<VelocityUnitKeyTestData> VelocityUnitKeyArgs =>
-        VelocityTestDataTuples.Select(unitArgs => new VelocityUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(VelocityShortNameArgs))]
-    public void VelocityUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Velocity> velocityUnit, double velocityValue, string expectedStr)
-    {
-        var velocity = new Velocity(velocityValue * velocityUnit.Ratio);
-        var resultStr = velocity.FormatAs(velocityUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(VelocityLongNameSingularFormArgs))]
-    public void VelocityUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Velocity> velocityUnit, string expectedStr)
-    {
-        var velocity = new Velocity(velocityUnit.Ratio);
-        var resultStr = velocity.FormatAs(velocityUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(VelocityLongNamePluralFormArgs))]
-    public void VelocityUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Velocity> velocityUnit, double velocityValue, string expectedStr)
-    {
-        var velocity = new Velocity(velocityValue * velocityUnit.Ratio);
-        var resultStr = velocity.FormatAs(velocityUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Velocity unit will return the expected unit key.
-    /// </summary>
-    /// <param name="velocityUnit">The velocity unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(VelocityUnitKeyArgs))]
-    public void GetVelocityUnitKey_ValidUnit_ReturnsUnitKey(Unit<Velocity> velocityUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, velocityUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Velocity>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Basic/VelocityTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/VelocityTests.cs
@@ -17,4 +17,7 @@ public class VelocityTests : BaseQuantityTests<VelocityTests, Velocity>, IQuanti
         new(Velocity.FeetPerSecond, "{0} ft/s", "1 foot per second", "{0} feet per second", "Quantity.Unit.Velocity.FeetPerSecond"),
         new(Velocity.Knots, "{0} kn", "1 knot", "{0} knots", "Quantity.Unit.Velocity.Knots")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Velocity> ExpectedDefaultUnit => Velocity.MetersPerSecond;
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/CurrentTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/CurrentTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 
@@ -38,7 +37,4 @@ public class CurrentTests : BaseQuantityTests<CurrentTests, Current>, IQuantityT
         new(SI<Current>.Ronna, "{0} RA", "1 ronnaampere", "{0} ronnaamperes", "Quantity.Unit.Electronic.Current.Ronnaamperes"),
         new(SI<Current>.Quetta, "{0} QA", "1 quettaampere", "{0} quettaamperes", "Quantity.Unit.Electronic.Current.Quettaamperes")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Current>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/CurrentTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/CurrentTests.cs
@@ -1,27 +1,16 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Electronic;
 
-using CurrentTestData = QuantityTestData<Current>;
-using CurrentUnitKeyTestData = (Unit<Current> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class CurrentTests
+public class CurrentTests : BaseQuantityTests<CurrentTests, Current>, IQuantityTestData<Current>
 {
-    /// <summary>
-    /// An array of test data tuples representing different current units and their display formats. Each
-    /// element in the array contains information about a current unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static CurrentTestData[] CurrentTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Current>[] TestDataTuples =>
     [
         new(Current.Ampere, "{0} A", "1 ampere", "{0} amperes", "Quantity.Unit.Electronic.Current.Amperes"),
         new(SI<Current>.Quecto, "{0} qA", "1 quectoampere", "{0} quectoamperes", "Quantity.Unit.Electronic.Current.Quectoamperes"),
@@ -50,79 +39,6 @@ public class CurrentTests
         new(SI<Current>.Quetta, "{0} QA", "1 quettaampere", "{0} quettaamperes", "Quantity.Unit.Electronic.Current.Quettaamperes")
     ];
 
-    internal static IEnumerable<object[]> CurrentShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            CurrentTestDataTuples.Select(currentUnitArgs => new object[] {
-                currentUnitArgs.unit, numValue, string.Format(currentUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> CurrentLongNameSingularFormArgs
-    {
-        get => CurrentTestDataTuples.Select(currentUnitArgs => new object[] {
-            currentUnitArgs.unit, currentUnitArgs.longNameSingle
-        });
-    }
-
-    internal static IEnumerable<object[]> CurrentLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            CurrentTestDataTuples.Select(currentUnitArgs => new object[] {
-                currentUnitArgs.unit, numValue, string.Format(currentUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for current units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<CurrentUnitKeyTestData> CurrentUnitKeyArgs =>
-        CurrentTestDataTuples.Select(unitArgs => new CurrentUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(CurrentShortNameArgs))]
-    public void CurrentUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Current> currentUnit, double currentValue, string expectedStr)
-    {
-        var current = new Current(currentValue * currentUnit.Ratio);
-        var resultStr = current.FormatAs(currentUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(CurrentLongNameSingularFormArgs))]
-    public void CurrentUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Current> currentUnit, string expectedStr)
-    {
-        var current = new Current(currentUnit.Ratio);
-        var resultStr = current.FormatAs(currentUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(CurrentLongNamePluralFormArgs))]
-    public void CurrentUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Current> currentUnit, double currentValue, string expectedStr)
-    {
-        var current = new Current(currentValue * currentUnit.Ratio);
-        var resultStr = current.FormatAs(currentUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Current unit will return the expected unit key.
-    /// </summary>
-    /// <param name="currentUnit">The current unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(CurrentUnitKeyArgs))]
-    public void GetCurrentUnitKey_ValidUnit_ReturnsUnitKey(Unit<Current> currentUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, currentUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Current>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/CurrentTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/CurrentTests.cs
@@ -37,4 +37,7 @@ public class CurrentTests : BaseQuantityTests<CurrentTests, Current>, IQuantityT
         new(SI<Current>.Ronna, "{0} RA", "1 ronnaampere", "{0} ronnaamperes", "Quantity.Unit.Electronic.Current.Ronnaamperes"),
         new(SI<Current>.Quetta, "{0} QA", "1 quettaampere", "{0} quettaamperes", "Quantity.Unit.Electronic.Current.Quettaamperes")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Current> ExpectedDefaultUnit => Current.Ampere;
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/ResistenceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/ResistenceTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Elements.Quantity.Test.Quantities.Electronic;
@@ -37,7 +36,4 @@ public class ResistanceTests : BaseQuantityTests<ResistanceTests, Resistance>, I
         new(SI<Resistance>.Ronna, "{0} RΩ", "1 ronnaohm", "{0} ronnaohms", "Quantity.Unit.Electronic.Resistance.Ronnaohms"),
         new(SI<Resistance>.Quetta, "{0} QΩ", "1 quettaohm", "{0} quettaohms", "Quantity.Unit.Electronic.Resistance.Quettaohms")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Resistance>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/ResistenceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/ResistenceTests.cs
@@ -1,128 +1,43 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-
 
 namespace Elements.Quantity.Test.Quantities.Electronic;
 
-using ResistanceTestData = QuantityTestData<Resistance>;
-using ResistanceUnitKeyTestData = (Unit<Resistance> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class ResistanceTests
+public class ResistanceTests : BaseQuantityTests<ResistanceTests, Resistance>, IQuantityTestData<Resistance>
 {
-    /// <summary>
-    /// An array of test data tuples representing different resistance units and their display formats. Each
-    /// element in the array contains information about a resistance unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static ResistanceTestData[] ResistanceTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Resistance>[] TestDataTuples =>
     [
-        new (Resistance.Ohm, "{0} Ω", "1 ohm", "{0} ohms", "Quantity.Unit.Electronic.Resistance.Ohms"),
-        new (SI<Resistance>.Quecto, "{0} qΩ", "1 quectoohm", "{0} quectoohms", "Quantity.Unit.Electronic.Resistance.Quectoohms"),
-        new (SI<Resistance>.Ronto, "{0} rΩ", "1 rontoohm", "{0} rontoohms", "Quantity.Unit.Electronic.Resistance.Rontoohms"),
-        new (SI<Resistance>.Yocto, "{0} yΩ", "1 yoctoohm", "{0} yoctoohms", "Quantity.Unit.Electronic.Resistance.Yoctoohms"),
-        new (SI<Resistance>.Zepto, "{0} zΩ", "1 zeptoohm", "{0} zeptoohms", "Quantity.Unit.Electronic.Resistance.Zeptoohms"),
-        new (SI<Resistance>.Atto, "{0} aΩ", "1 attoohm", "{0} attoohms", "Quantity.Unit.Electronic.Resistance.Attoohms"),
-        new (SI<Resistance>.Femto, "{0} fΩ", "1 femtoohm", "{0} femtoohms", "Quantity.Unit.Electronic.Resistance.Femtoohms"),
-        new (SI<Resistance>.Pico, "{0} pΩ", "1 picoohm", "{0} picoohms", "Quantity.Unit.Electronic.Resistance.Picoohms"),
-        new (SI<Resistance>.Nano, "{0} nΩ", "1 nanoohm", "{0} nanoohms", "Quantity.Unit.Electronic.Resistance.Nanoohms"),
-        new (SI<Resistance>.Micro, "{0} µΩ", "1 microohm", "{0} microohms", "Quantity.Unit.Electronic.Resistance.Microohms"),
-        new (SI<Resistance>.Centi, "{0} cΩ", "1 centiohm", "{0} centiohms", "Quantity.Unit.Electronic.Resistance.Centiohms"),
-        new (SI<Resistance>.Deci, "{0} dΩ", "1 deciohm", "{0} deciohms", "Quantity.Unit.Electronic.Resistance.Deciohms"),
-        new (SI<Resistance>.Deca, "{0} daΩ", "1 decaohm", "{0} decaohms", "Quantity.Unit.Electronic.Resistance.Decaohms"),
-        new (SI<Resistance>.Hecto, "{0} hΩ", "1 hectoohm", "{0} hectoohms", "Quantity.Unit.Electronic.Resistance.Hectoohms"),
-        new (SI<Resistance>.Milli, "{0} mΩ", "1 milliohm", "{0} milliohms", "Quantity.Unit.Electronic.Resistance.Milliohms"),
-        new (SI<Resistance>.Kilo, "{0} kΩ", "1 kiloohm", "{0} kiloohms", "Quantity.Unit.Electronic.Resistance.Kiloohms"),
-        new (SI<Resistance>.Mega, "{0} MΩ", "1 megaohm", "{0} megaohms", "Quantity.Unit.Electronic.Resistance.Megaohms"),
-        new (SI<Resistance>.Giga, "{0} GΩ", "1 gigaohm", "{0} gigaohms", "Quantity.Unit.Electronic.Resistance.Gigaohms"),
-        new (SI<Resistance>.Tera, "{0} TΩ", "1 teraohm", "{0} teraohms", "Quantity.Unit.Electronic.Resistance.Teraohms"),
-        new (SI<Resistance>.Peta, "{0} PΩ", "1 petaohm", "{0} petaohms", "Quantity.Unit.Electronic.Resistance.Petaohms"),
-        new (SI<Resistance>.Exa, "{0} EΩ", "1 exaohm", "{0} exaohms", "Quantity.Unit.Electronic.Resistance.Exaohms"),
-        new (SI<Resistance>.Zetta, "{0} ZΩ", "1 zettaohm", "{0} zettaohms", "Quantity.Unit.Electronic.Resistance.Zettaohms"),
-        new (SI<Resistance>.Yotta, "{0} YΩ", "1 yottaohm", "{0} yottaohms", "Quantity.Unit.Electronic.Resistance.Yottaohms"),
-        new (SI<Resistance>.Ronna, "{0} RΩ", "1 ronnaohm", "{0} ronnaohms", "Quantity.Unit.Electronic.Resistance.Ronnaohms"),
-        new (SI<Resistance>.Quetta, "{0} QΩ", "1 quettaohm", "{0} quettaohms", "Quantity.Unit.Electronic.Resistance.Quettaohms")
+        new(Resistance.Ohm, "{0} Ω", "1 ohm", "{0} ohms", "Quantity.Unit.Electronic.Resistance.Ohms"),
+        new(SI<Resistance>.Quecto, "{0} qΩ", "1 quectoohm", "{0} quectoohms", "Quantity.Unit.Electronic.Resistance.Quectoohms"),
+        new(SI<Resistance>.Ronto, "{0} rΩ", "1 rontoohm", "{0} rontoohms", "Quantity.Unit.Electronic.Resistance.Rontoohms"),
+        new(SI<Resistance>.Yocto, "{0} yΩ", "1 yoctoohm", "{0} yoctoohms", "Quantity.Unit.Electronic.Resistance.Yoctoohms"),
+        new(SI<Resistance>.Zepto, "{0} zΩ", "1 zeptoohm", "{0} zeptoohms", "Quantity.Unit.Electronic.Resistance.Zeptoohms"),
+        new(SI<Resistance>.Atto, "{0} aΩ", "1 attoohm", "{0} attoohms", "Quantity.Unit.Electronic.Resistance.Attoohms"),
+        new(SI<Resistance>.Femto, "{0} fΩ", "1 femtoohm", "{0} femtoohms", "Quantity.Unit.Electronic.Resistance.Femtoohms"),
+        new(SI<Resistance>.Pico, "{0} pΩ", "1 picoohm", "{0} picoohms", "Quantity.Unit.Electronic.Resistance.Picoohms"),
+        new(SI<Resistance>.Nano, "{0} nΩ", "1 nanoohm", "{0} nanoohms", "Quantity.Unit.Electronic.Resistance.Nanoohms"),
+        new(SI<Resistance>.Micro, "{0} µΩ", "1 microohm", "{0} microohms", "Quantity.Unit.Electronic.Resistance.Microohms"),
+        new(SI<Resistance>.Centi, "{0} cΩ", "1 centiohm", "{0} centiohms", "Quantity.Unit.Electronic.Resistance.Centiohms"),
+        new(SI<Resistance>.Deci, "{0} dΩ", "1 deciohm", "{0} deciohms", "Quantity.Unit.Electronic.Resistance.Deciohms"),
+        new(SI<Resistance>.Deca, "{0} daΩ", "1 decaohm", "{0} decaohms", "Quantity.Unit.Electronic.Resistance.Decaohms"),
+        new(SI<Resistance>.Hecto, "{0} hΩ", "1 hectoohm", "{0} hectoohms", "Quantity.Unit.Electronic.Resistance.Hectoohms"),
+        new(SI<Resistance>.Milli, "{0} mΩ", "1 milliohm", "{0} milliohms", "Quantity.Unit.Electronic.Resistance.Milliohms"),
+        new(SI<Resistance>.Kilo, "{0} kΩ", "1 kiloohm", "{0} kiloohms", "Quantity.Unit.Electronic.Resistance.Kiloohms"),
+        new(SI<Resistance>.Mega, "{0} MΩ", "1 megaohm", "{0} megaohms", "Quantity.Unit.Electronic.Resistance.Megaohms"),
+        new(SI<Resistance>.Giga, "{0} GΩ", "1 gigaohm", "{0} gigaohms", "Quantity.Unit.Electronic.Resistance.Gigaohms"),
+        new(SI<Resistance>.Tera, "{0} TΩ", "1 teraohm", "{0} teraohms", "Quantity.Unit.Electronic.Resistance.Teraohms"),
+        new(SI<Resistance>.Peta, "{0} PΩ", "1 petaohm", "{0} petaohms", "Quantity.Unit.Electronic.Resistance.Petaohms"),
+        new(SI<Resistance>.Exa, "{0} EΩ", "1 exaohm", "{0} exaohms", "Quantity.Unit.Electronic.Resistance.Exaohms"),
+        new(SI<Resistance>.Zetta, "{0} ZΩ", "1 zettaohm", "{0} zettaohms", "Quantity.Unit.Electronic.Resistance.Zettaohms"),
+        new(SI<Resistance>.Yotta, "{0} YΩ", "1 yottaohm", "{0} yottaohms", "Quantity.Unit.Electronic.Resistance.Yottaohms"),
+        new(SI<Resistance>.Ronna, "{0} RΩ", "1 ronnaohm", "{0} ronnaohms", "Quantity.Unit.Electronic.Resistance.Ronnaohms"),
+        new(SI<Resistance>.Quetta, "{0} QΩ", "1 quettaohm", "{0} quettaohms", "Quantity.Unit.Electronic.Resistance.Quettaohms")
     ];
 
-    internal static IEnumerable<object[]> ResistanceShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            ResistanceTestDataTuples.Select(resistanceUnitArgs => new object[] {
-                resistanceUnitArgs.unit, numValue, string.Format(resistanceUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> ResistanceLongNameSingularFormArgs
-    {
-        get => ResistanceTestDataTuples.Select(resistanceUnitArgs => new object[] {
-            resistanceUnitArgs.unit, resistanceUnitArgs.longNameSingle
-        });
-    }
-
-    internal static IEnumerable<object[]> ResistanceLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            ResistanceTestDataTuples.Select(resistanceUnitArgs => new object[] {
-                resistanceUnitArgs.unit, numValue, string.Format(resistanceUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for resistance units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<ResistanceUnitKeyTestData> ResistanceUnitKeyArgs =>
-        ResistanceTestDataTuples.Select(unitArgs => new ResistanceUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(ResistanceShortNameArgs))]
-    public void ResistanceUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Resistance> resistanceUnit, double resistanceValue, string expectedStr)
-    {
-        var resistance = new Resistance(resistanceValue * resistanceUnit.Ratio);
-        var resultStr = resistance.FormatAs(resistanceUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(ResistanceLongNameSingularFormArgs))]
-    public void ResistanceUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Resistance> resistanceUnit, string expectedStr)
-    {
-        var resistance = new Resistance(resistanceUnit.Ratio);
-        var resultStr = resistance.FormatAs(resistanceUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(ResistanceLongNamePluralFormArgs))]
-    public void ResistanceUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Resistance> resistanceUnit, double resistanceValue, string expectedStr)
-    {
-        var resistance = new Resistance(resistanceValue * resistanceUnit.Ratio);
-        var resultStr = resistance.FormatAs(resistanceUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Resistance unit will return the expected unit key.
-    /// </summary>
-    /// <param name="resistanceUnit">The resistance unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(ResistanceUnitKeyArgs))]
-    public void GetResistanceUnitKey_ValidUnit_ReturnsUnitKey(Unit<Resistance> resistanceUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, resistanceUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Resistance>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/ResistenceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/ResistenceTests.cs
@@ -36,4 +36,7 @@ public class ResistanceTests : BaseQuantityTests<ResistanceTests, Resistance>, I
         new(SI<Resistance>.Ronna, "{0} RΩ", "1 ronnaohm", "{0} ronnaohms", "Quantity.Unit.Electronic.Resistance.Ronnaohms"),
         new(SI<Resistance>.Quetta, "{0} QΩ", "1 quettaohm", "{0} quettaohms", "Quantity.Unit.Electronic.Resistance.Quettaohms")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Resistance> ExpectedDefaultUnit => Resistance.Ohm;
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/VoltageTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/VoltageTests.cs
@@ -1,128 +1,44 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 
 
 namespace Elements.Quantity.Test.Quantities.Electronic;
 
-using VoltageTestData = QuantityTestData<Voltage>;
-using VoltageUnitKeyTestData = (Unit<Voltage> unit, string unitKey);
-
 [TestClass]
 [ExcludeFromCodeCoverage]
-public class VoltageTests
+public class VoltageTests : BaseQuantityTests<VoltageTests, Voltage>, IQuantityTestData<Voltage>
 {
-    /// <summary>
-    /// An array of test data tuples representing different voltage units and their display formats. Each
-    /// element in the array contains information about a voltage unit, the short name, the singular
-    /// long name, plural long name, and unit key.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static VoltageTestData[] VoltageTestDataTuples =>
+    /// <inheritdoc/>
+    public static QuantityTestData<Voltage>[] TestDataTuples =>
     [
-        new (Voltage.Volt, "{0} V", "1 volt", "{0} volts", "Quantity.Unit.Electronic.Voltage.Volts"),
-        new (SI<Voltage>.Quecto, "{0} qV", "1 quectovolt", "{0} quectovolts", "Quantity.Unit.Electronic.Voltage.Quectovolts"),
-        new (SI<Voltage>.Ronto, "{0} rV", "1 rontovolt", "{0} rontovolts", "Quantity.Unit.Electronic.Voltage.Rontovolts"),
-        new (SI<Voltage>.Yocto, "{0} yV", "1 yoctovolt", "{0} yoctovolts", "Quantity.Unit.Electronic.Voltage.Yoctovolts"),
-        new (SI<Voltage>.Zepto, "{0} zV", "1 zeptovolt", "{0} zeptovolts", "Quantity.Unit.Electronic.Voltage.Zeptovolts"),
-        new (SI<Voltage>.Atto, "{0} aV", "1 attovolt", "{0} attovolts", "Quantity.Unit.Electronic.Voltage.Attovolts"),
-        new (SI<Voltage>.Femto, "{0} fV", "1 femtovolt", "{0} femtovolts", "Quantity.Unit.Electronic.Voltage.Femtovolts"),
-        new (SI<Voltage>.Pico, "{0} pV", "1 picovolt", "{0} picovolts", "Quantity.Unit.Electronic.Voltage.Picovolts"),
-        new (SI<Voltage>.Nano, "{0} nV", "1 nanovolt", "{0} nanovolts", "Quantity.Unit.Electronic.Voltage.Nanovolts"),
-        new (SI<Voltage>.Micro, "{0} µV", "1 microvolt", "{0} microvolts", "Quantity.Unit.Electronic.Voltage.Microvolts"),
-        new (SI<Voltage>.Centi, "{0} cV", "1 centivolt", "{0} centivolts", "Quantity.Unit.Electronic.Voltage.Centivolts"),
-        new (SI<Voltage>.Deci, "{0} dV", "1 decivolt", "{0} decivolts", "Quantity.Unit.Electronic.Voltage.Decivolts"),
-        new (SI<Voltage>.Deca, "{0} daV", "1 decavolt", "{0} decavolts", "Quantity.Unit.Electronic.Voltage.Decavolts"),
-        new (SI<Voltage>.Hecto, "{0} hV", "1 hectovolt", "{0} hectovolts", "Quantity.Unit.Electronic.Voltage.Hectovolts"),
-        new (SI<Voltage>.Milli, "{0} mV", "1 millivolt", "{0} millivolts", "Quantity.Unit.Electronic.Voltage.Millivolts"),
-        new (SI<Voltage>.Kilo, "{0} kV", "1 kilovolt", "{0} kilovolts", "Quantity.Unit.Electronic.Voltage.Kilovolts"),
-        new (SI<Voltage>.Mega, "{0} MV", "1 megavolt", "{0} megavolts", "Quantity.Unit.Electronic.Voltage.Megavolts"),
-        new (SI<Voltage>.Giga, "{0} GV", "1 gigavolt", "{0} gigavolts", "Quantity.Unit.Electronic.Voltage.Gigavolts"),
-        new (SI<Voltage>.Tera, "{0} TV", "1 teravolt", "{0} teravolts", "Quantity.Unit.Electronic.Voltage.Teravolts"),
-        new (SI<Voltage>.Peta, "{0} PV", "1 petavolt", "{0} petavolts", "Quantity.Unit.Electronic.Voltage.Petavolts"),
-        new (SI<Voltage>.Exa, "{0} EV", "1 exavolt", "{0} exavolts", "Quantity.Unit.Electronic.Voltage.Exavolts"),
-        new (SI<Voltage>.Zetta, "{0} ZV", "1 zettavolt", "{0} zettavolts", "Quantity.Unit.Electronic.Voltage.Zettavolts"),
-        new (SI<Voltage>.Yotta, "{0} YV", "1 yottavolt", "{0} yottavolts", "Quantity.Unit.Electronic.Voltage.Yottavolts"),
-        new (SI<Voltage>.Ronna, "{0} RV", "1 ronnavolt", "{0} ronnavolts", "Quantity.Unit.Electronic.Voltage.Ronnavolts"),
-        new (SI<Voltage>.Quetta, "{0} QV", "1 quettavolt", "{0} quettavolts", "Quantity.Unit.Electronic.Voltage.Quettavolts")
+        new(Voltage.Volt, "{0} V", "1 volt", "{0} volts", "Quantity.Unit.Electronic.Voltage.Volts"),
+        new(SI<Voltage>.Quecto, "{0} qV", "1 quectovolt", "{0} quectovolts", "Quantity.Unit.Electronic.Voltage.Quectovolts"),
+        new(SI<Voltage>.Ronto, "{0} rV", "1 rontovolt", "{0} rontovolts", "Quantity.Unit.Electronic.Voltage.Rontovolts"),
+        new(SI<Voltage>.Yocto, "{0} yV", "1 yoctovolt", "{0} yoctovolts", "Quantity.Unit.Electronic.Voltage.Yoctovolts"),
+        new(SI<Voltage>.Zepto, "{0} zV", "1 zeptovolt", "{0} zeptovolts", "Quantity.Unit.Electronic.Voltage.Zeptovolts"),
+        new(SI<Voltage>.Atto, "{0} aV", "1 attovolt", "{0} attovolts", "Quantity.Unit.Electronic.Voltage.Attovolts"),
+        new(SI<Voltage>.Femto, "{0} fV", "1 femtovolt", "{0} femtovolts", "Quantity.Unit.Electronic.Voltage.Femtovolts"),
+        new(SI<Voltage>.Pico, "{0} pV", "1 picovolt", "{0} picovolts", "Quantity.Unit.Electronic.Voltage.Picovolts"),
+        new(SI<Voltage>.Nano, "{0} nV", "1 nanovolt", "{0} nanovolts", "Quantity.Unit.Electronic.Voltage.Nanovolts"),
+        new(SI<Voltage>.Micro, "{0} µV", "1 microvolt", "{0} microvolts", "Quantity.Unit.Electronic.Voltage.Microvolts"),
+        new(SI<Voltage>.Centi, "{0} cV", "1 centivolt", "{0} centivolts", "Quantity.Unit.Electronic.Voltage.Centivolts"),
+        new(SI<Voltage>.Deci, "{0} dV", "1 decivolt", "{0} decivolts", "Quantity.Unit.Electronic.Voltage.Decivolts"),
+        new(SI<Voltage>.Deca, "{0} daV", "1 decavolt", "{0} decavolts", "Quantity.Unit.Electronic.Voltage.Decavolts"),
+        new(SI<Voltage>.Hecto, "{0} hV", "1 hectovolt", "{0} hectovolts", "Quantity.Unit.Electronic.Voltage.Hectovolts"),
+        new(SI<Voltage>.Milli, "{0} mV", "1 millivolt", "{0} millivolts", "Quantity.Unit.Electronic.Voltage.Millivolts"),
+        new(SI<Voltage>.Kilo, "{0} kV", "1 kilovolt", "{0} kilovolts", "Quantity.Unit.Electronic.Voltage.Kilovolts"),
+        new(SI<Voltage>.Mega, "{0} MV", "1 megavolt", "{0} megavolts", "Quantity.Unit.Electronic.Voltage.Megavolts"),
+        new(SI<Voltage>.Giga, "{0} GV", "1 gigavolt", "{0} gigavolts", "Quantity.Unit.Electronic.Voltage.Gigavolts"),
+        new(SI<Voltage>.Tera, "{0} TV", "1 teravolt", "{0} teravolts", "Quantity.Unit.Electronic.Voltage.Teravolts"),
+        new(SI<Voltage>.Peta, "{0} PV", "1 petavolt", "{0} petavolts", "Quantity.Unit.Electronic.Voltage.Petavolts"),
+        new(SI<Voltage>.Exa, "{0} EV", "1 exavolt", "{0} exavolts", "Quantity.Unit.Electronic.Voltage.Exavolts"),
+        new(SI<Voltage>.Zetta, "{0} ZV", "1 zettavolt", "{0} zettavolts", "Quantity.Unit.Electronic.Voltage.Zettavolts"),
+        new(SI<Voltage>.Yotta, "{0} YV", "1 yottavolt", "{0} yottavolts", "Quantity.Unit.Electronic.Voltage.Yottavolts"),
+        new(SI<Voltage>.Ronna, "{0} RV", "1 ronnavolt", "{0} ronnavolts", "Quantity.Unit.Electronic.Voltage.Ronnavolts"),
+        new(SI<Voltage>.Quetta, "{0} QV", "1 quettavolt", "{0} quettavolts", "Quantity.Unit.Electronic.Voltage.Quettavolts")
     ];
 
-    internal static IEnumerable<object[]> VoltageShortNameArgs
-    {
-        get => DataProvider.UnitQuantityShortNameNumberValues.SelectMany(numValue =>
-            VoltageTestDataTuples.Select(voltageUnitArgs => new object[] {
-                voltageUnitArgs.unit, numValue, string.Format(voltageUnitArgs.shortName, numValue)
-            }).ToArray()
-        );
-    }
-
-    internal static IEnumerable<object[]> VoltageLongNameSingularFormArgs
-    {
-        get => VoltageTestDataTuples.Select(voltageUnitArgs => new object[] {
-            voltageUnitArgs.unit, voltageUnitArgs.longNameSingle
-        });
-    }
-
-    internal static IEnumerable<object[]> VoltageLongNamePluralFormArgs
-    {
-        get => DataProvider.UnitQuantityPluralNumberValues.SelectMany(numValue =>
-            VoltageTestDataTuples.Select(voltageUnitArgs => new object[] {
-                voltageUnitArgs.unit, numValue, string.Format(voltageUnitArgs.longNamePlural, numValue)
-            }).ToArray()
-        );
-    }
-
-    /// <summary>
-    /// A collection of test arguments for verifying the unit keys for voltage units.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests.
-    /// </remarks>
-    internal static IEnumerable<VoltageUnitKeyTestData> VoltageUnitKeyArgs =>
-        VoltageTestDataTuples.Select(unitArgs => new VoltageUnitKeyTestData(unitArgs.unit, unitArgs.unitKey));
-
-    [TestMethod]
-    [DynamicData(nameof(VoltageShortNameArgs))]
-    public void VoltageUnit_QuantityProvidedFormatAsShortName_FormatsWithDefaultShortName(Unit<Voltage> voltageUnit, double voltageValue, string expectedStr)
-    {
-        var voltage = new Voltage(voltageValue * voltageUnit.Ratio);
-        var resultStr = voltage.FormatAs(voltageUnit, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(VoltageLongNameSingularFormArgs))]
-    public void VoltageUnit_QuantitySingleValueFormatAsLongName_FormatsWithDefaultLongNameSingularForm(Unit<Voltage> voltageUnit, string expectedStr)
-    {
-        var voltage = new Voltage(voltageUnit.Ratio);
-        var resultStr = voltage.FormatAs(voltageUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    [TestMethod]
-    [DynamicData(nameof(VoltageLongNamePluralFormArgs))]
-    public void VoltageUnit_QuantityPluralValueFormatAsLongName_FormatsWithDefaultLongNamePluralForm(Unit<Voltage> voltageUnit, double voltageValue, string expectedStr)
-    {
-        var voltage = new Voltage(voltageValue * voltageUnit.Ratio);
-        var resultStr = voltage.FormatAs(voltageUnit, longName: true, formatNum: "0.#");
-
-        Assert.AreEqual(expectedStr, resultStr);
-    }
-
-    /// <summary>
-    /// Verifies that getting a unit key from an Voltage unit will return the expected unit key.
-    /// </summary>
-    /// <param name="voltageUnit">The voltage unit to use when getting the unit key.</param>
-    /// <param name="expectedUnitKey">The expected unit key that this unit should return.</param>
-    [TestMethod]
-    [DynamicData(nameof(VoltageUnitKeyArgs))]
-    public void GetVoltageUnitKey_ValidUnit_ReturnsUnitKey(Unit<Voltage> voltageUnit, string expectedUnitKey)
-    {
-        Assert.AreEqual(expectedUnitKey, voltageUnit.UnitKey);
-    }
+    /// <inheritdoc/>
+    public static IEnumerable<QuantityFormatTestData<Voltage>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/VoltageTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/VoltageTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 
@@ -38,7 +37,4 @@ public class VoltageTests : BaseQuantityTests<VoltageTests, Voltage>, IQuantityT
         new(SI<Voltage>.Ronna, "{0} RV", "1 ronnavolt", "{0} ronnavolts", "Quantity.Unit.Electronic.Voltage.Ronnavolts"),
         new(SI<Voltage>.Quetta, "{0} QV", "1 quettavolt", "{0} quettavolts", "Quantity.Unit.Electronic.Voltage.Quettavolts")
     ];
-
-    /// <inheritdoc/>
-    public static IEnumerable<QuantityFormatTestData<Voltage>>? CompoundFormatInfoDataTuples => null;
 }

--- a/Elements.Quantity.Tests/Quantities/Electronic/VoltageTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Electronic/VoltageTests.cs
@@ -37,4 +37,7 @@ public class VoltageTests : BaseQuantityTests<VoltageTests, Voltage>, IQuantityT
         new(SI<Voltage>.Ronna, "{0} RV", "1 ronnavolt", "{0} ronnavolts", "Quantity.Unit.Electronic.Voltage.Ronnavolts"),
         new(SI<Voltage>.Quetta, "{0} QV", "1 quettavolt", "{0} quettavolts", "Quantity.Unit.Electronic.Voltage.Quettavolts")
     ];
+
+    /// <inheritdoc/>
+    public sealed override Unit<Voltage> ExpectedDefaultUnit => Voltage.Volt;
 }

--- a/Elements.Quantity.Tests/Quantities/IQuantityCompoundFormattedTestData.cs
+++ b/Elements.Quantity.Tests/Quantities/IQuantityCompoundFormattedTestData.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Elements.Quantity.Test.Quantities;
+
+public interface IQuantityCompoundFormattedTestData<TQuantity> : IQuantityTestData<TQuantity>
+where TQuantity : unmanaged, IQuantity<TQuantity>
+{
+    /// <summary>
+    /// An array of test data tuples representing different combinations of <see cref="CompoundFormatInfo{TQuantity}"/> and
+    /// <typeparamref name="TQuantity"/> with their expected text representation.
+    /// Each element in the array contains the format, input base value, and expected string.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    static abstract IEnumerable<QuantityFormatTestData<TQuantity>> CompoundFormatInfoDataTuples { get; }
+}

--- a/Elements.Quantity.Tests/Quantities/IQuantityTestData.cs
+++ b/Elements.Quantity.Tests/Quantities/IQuantityTestData.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace Elements.Quantity.Test.Quantities;
+
+public interface IQuantityTestData<TQuantity>
+where TQuantity : unmanaged, IQuantity<TQuantity>
+{
+    /// <summary>
+    /// An array of test data tuples representing different <typeparamref name="TQuantity"/> units and their display formats. Each
+    /// element in the array contains information about a <typeparamref name="TQuantity"/> unit, the short name, the singular
+    /// long name, plural long name, and unit key.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests.
+    /// </remarks>
+    static abstract QuantityTestData<TQuantity>[] TestDataTuples { get; }
+
+    /// <summary>
+    /// An array of test data tuples representing different combinations of <see cref="CompoundFormatInfo{TQuantity}"/> and
+    /// <typeparamref name="TQuantity"/> with their expected text representation.
+    /// Each element in the array contains the format, input base value, and expected string.
+    /// </summary>
+    /// <remarks>
+    /// This property is intended for use in unit tests. Return <code>null</code> if there are no test cases.
+    /// </remarks>
+    static abstract IEnumerable<QuantityFormatTestData<TQuantity>>? CompoundFormatInfoDataTuples { get; }
+}

--- a/Elements.Quantity.Tests/Quantities/IQuantityTestData.cs
+++ b/Elements.Quantity.Tests/Quantities/IQuantityTestData.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Elements.Quantity.Test.Quantities;
 
 public interface IQuantityTestData<TQuantity>
@@ -14,14 +12,4 @@ where TQuantity : unmanaged, IQuantity<TQuantity>
     /// This property is intended for use in unit tests.
     /// </remarks>
     static abstract QuantityTestData<TQuantity>[] TestDataTuples { get; }
-
-    /// <summary>
-    /// An array of test data tuples representing different combinations of <see cref="CompoundFormatInfo{TQuantity}"/> and
-    /// <typeparamref name="TQuantity"/> with their expected text representation.
-    /// Each element in the array contains the format, input base value, and expected string.
-    /// </summary>
-    /// <remarks>
-    /// This property is intended for use in unit tests. Return <code>null</code> if there are no test cases.
-    /// </remarks>
-    static abstract IEnumerable<QuantityFormatTestData<TQuantity>>? CompoundFormatInfoDataTuples { get; }
 }

--- a/Elements.Quantity.Tests/QuantityFormatTestData.cs
+++ b/Elements.Quantity.Tests/QuantityFormatTestData.cs
@@ -1,0 +1,8 @@
+namespace Elements.Quantity.Test;
+
+public readonly record struct QuantityFormatTestData<TQuantity>(
+    CompoundFormatInfo<TQuantity> Format,
+    double Value,
+    string ExpectedStr
+)
+where TQuantity : unmanaged, IQuantity<TQuantity>;

--- a/Elements.Quantity.Tests/QuantityTestData.cs
+++ b/Elements.Quantity.Tests/QuantityTestData.cs
@@ -1,6 +1,6 @@
 ﻿namespace Elements.Quantity.Test;
 
-internal readonly record struct QuantityTestData<T>(
+public readonly record struct QuantityTestData<T>(
     Unit<T> unit,
     string shortName,
     string longNameSingle,

--- a/Elements.Quantity/Core/QuantityHelper.cs
+++ b/Elements.Quantity/Core/QuantityHelper.cs
@@ -61,7 +61,7 @@ namespace Elements.Quantity
             Unit<T>? selectedUnit = null;
 
             if (q.BaseValue == 0)
-                selectedUnit = defaultUnit ?? q.DefaultUnit;
+                selectedUnit = defaultUnit ?? T.DefaultUnitDefinition;
             else
                 selectedUnit = SelectBestUnit(q, groups ?? UnitGroup.DefaultUnitGroups);
 

--- a/Elements.Quantity/Core/QuantityInterfaces.cs
+++ b/Elements.Quantity/Core/QuantityInterfaces.cs
@@ -27,7 +27,10 @@ namespace Elements.Quantity
         T Divide(double n);
         Ratio Divide(T q);
 
+        [Obsolete("Use 'Unit<T>.DefaultUnitDefinition' instead.")]
         Unit<T> DefaultUnit { get; }
+
+        static abstract Unit<T> DefaultUnitDefinition { get; }
 
         /// <summary>
         /// The quantity family that this quantity type belongs to.

--- a/Elements.Quantity/Core/Unit.cs
+++ b/Elements.Quantity/Core/Unit.cs
@@ -173,7 +173,7 @@ namespace Elements.Quantity
 
             if (noUnit)
             {
-                var unit = defaultUnit ?? default(T).DefaultUnit;
+                var unit = defaultUnit ?? T.DefaultUnitDefinition;
                 quantity = unit.ConvertFrom(val);
                 return true;
             }

--- a/Elements.Quantity/Quantities/Basic/Acceleration.cs
+++ b/Elements.Quantity/Quantities/Basic/Acceleration.cs
@@ -37,7 +37,10 @@ namespace Elements.Quantity
         #region UNITS
 
         // provide a default unit for the quantity - used when no explicit unit specified
-        public Unit<Acceleration> DefaultUnit { get { return MetersPerSecondPerSecond; } }
+        [Obsolete("Use 'Unit<Acceleration>.DefaultUnitDefinition' instead.")]
+        public Unit<Acceleration> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Acceleration> DefaultUnitDefinition => MetersPerSecondPerSecond;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Angle.cs
+++ b/Elements.Quantity/Quantities/Basic/Angle.cs
@@ -68,7 +68,10 @@ namespace Elements.Quantity
         #region UNITS
 
         // provide a default unit for the quantity - used when no explicit unit specified
-        public Unit<Angle> DefaultUnit { get { return Radian; } }
+        [Obsolete("Use 'Unit<Angle>.DefaultUnitDefinition' instead.")]
+        public Unit<Angle> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Angle> DefaultUnitDefinition => Radian;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Density.cs
+++ b/Elements.Quantity/Quantities/Basic/Density.cs
@@ -26,7 +26,10 @@ namespace Elements.Quantity
 
         #region UNITS
 
-        public Unit<Density> DefaultUnit { get { return KilogramPerCubicMeter; } }
+        [Obsolete("Use 'Unit<Density>.DefaultUnitDefinition' instead.")]
+        public Unit<Density> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Density> DefaultUnitDefinition => KilogramPerCubicMeter;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Distance.cs
+++ b/Elements.Quantity/Quantities/Basic/Distance.cs
@@ -64,7 +64,10 @@ namespace Elements.Quantity
 
         #region UNITS
 
-        public Unit<Distance> DefaultUnit { get { return Meter; } }
+        [Obsolete("Use 'Unit<Distance>.DefaultUnitDefinition' instead.")]
+        public Unit<Distance> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Distance> DefaultUnitDefinition => Meter;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Luminance.cs
+++ b/Elements.Quantity/Quantities/Basic/Luminance.cs
@@ -26,7 +26,10 @@ namespace Elements.Quantity
 
         #region UNITS
 
-        public Unit<Luminance> DefaultUnit { get { return CandelaPerSquareMeter; } }
+        [Obsolete("Use 'Unit<Luminance>.DefaultUnitDefinition' instead.")]
+        public Unit<Luminance> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Luminance> DefaultUnitDefinition => CandelaPerSquareMeter;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Mass.cs
+++ b/Elements.Quantity/Quantities/Basic/Mass.cs
@@ -69,7 +69,10 @@ namespace Elements.Quantity
         #region UNITS
 
         // provide a default unit for the quantity - used when no explicit unit specified
-        public Unit<Mass> DefaultUnit { get { return SI<Mass>.Kilo; } }
+        [Obsolete("Use 'Unit<Mass>.DefaultUnitDefinition' instead.")]
+        public Unit<Mass> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Mass> DefaultUnitDefinition => SI<Mass>.Kilo;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Pressure.cs
+++ b/Elements.Quantity/Quantities/Basic/Pressure.cs
@@ -75,7 +75,10 @@ namespace Elements.Quantity
 
         #region UNITS
 
-        public Unit<Pressure> DefaultUnit { get { return Pascal; } }
+        [Obsolete("Use 'Unit<Pressure>.DefaultUnitDefinition' instead.")]
+        public Unit<Pressure> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Pressure> DefaultUnitDefinition => Pascal;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Ratio.cs
+++ b/Elements.Quantity/Quantities/Basic/Ratio.cs
@@ -37,7 +37,10 @@ namespace Elements.Quantity
         #region UNITS
 
         // provide a default unit for the quantity - used when no explicit unit specified
-        public Unit<Ratio> DefaultUnit { get { return RatioValue; } }
+        [Obsolete("Use 'Unit<Ratio>.DefaultUnitDefinition' instead.")]
+        public Unit<Ratio> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Ratio> DefaultUnitDefinition => RatioValue;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Temperature.cs
+++ b/Elements.Quantity/Quantities/Basic/Temperature.cs
@@ -37,7 +37,10 @@ namespace Elements.Quantity
         #region UNITS
 
         // provide a default unit for the quantity - used when no explicit unit specified
-        public Unit<Temperature> DefaultUnit { get { return Kelvin; } }
+        [Obsolete("Use 'Unit<Temperature>.DefaultUnitDefinition' instead.")]
+        public Unit<Temperature> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Temperature> DefaultUnitDefinition => Kelvin;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Time.cs
+++ b/Elements.Quantity/Quantities/Basic/Time.cs
@@ -37,7 +37,10 @@ namespace Elements.Quantity
         #region UNITS
 
         // provide a default unit for the quantity - used when no explicit unit specified
-        public Unit<Time> DefaultUnit { get { return Second; } }
+        [Obsolete("Use 'Unit<Time>.DefaultUnitDefinition' instead.")]
+        public Unit<Time> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Time> DefaultUnitDefinition => Second;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Torque.cs
+++ b/Elements.Quantity/Quantities/Basic/Torque.cs
@@ -26,7 +26,10 @@ namespace Elements.Quantity
 
         #region UNITS
 
-        public Unit<Torque> DefaultUnit { get { return NewtonMeter; } }
+        [Obsolete("Use 'Unit<Torque>.DefaultUnitDefinition' instead.")]
+        public Unit<Torque> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Torque> DefaultUnitDefinition => NewtonMeter;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Basic/Velocity.cs
+++ b/Elements.Quantity/Quantities/Basic/Velocity.cs
@@ -37,7 +37,10 @@ namespace Elements.Quantity
         #region UNITS
 
         // provide a default unit for the quantity - used when no explicit unit specified
-        public Unit<Velocity> DefaultUnit { get { return MetersPerSecond; } }
+        [Obsolete("Use 'Unit<Velocity>.DefaultUnitDefinition' instead.")]
+        public Unit<Velocity> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Velocity> DefaultUnitDefinition => MetersPerSecond;
 
         /// <inheritdoc/>
         public string QuantityFamily => string.Empty;

--- a/Elements.Quantity/Quantities/Electronic/Current.cs
+++ b/Elements.Quantity/Quantities/Electronic/Current.cs
@@ -84,7 +84,10 @@ namespace Elements.Quantity
         #region UNITS
 
         // provide a default unit for the quantity - used when no explicit unit specified
-        public Unit<Current> DefaultUnit { get { return Ampere; } }
+        [Obsolete("Use 'Unit<Current>.DefaultUnitDefinition' instead.")]
+        public Unit<Current> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Current> DefaultUnitDefinition => Ampere;
 
         /// <inheritdoc/>
         public string QuantityFamily => "Electronic";

--- a/Elements.Quantity/Quantities/Electronic/Resistance.cs
+++ b/Elements.Quantity/Quantities/Electronic/Resistance.cs
@@ -84,7 +84,10 @@ namespace Elements.Quantity
         #region UNITS
 
         // provide a default unit for the quantity - used when no explicit unit specified
-        public Unit<Resistance> DefaultUnit { get { return Ohm; } }
+        [Obsolete("Use 'Unit<Resistance>.DefaultUnitDefinition' instead.")]
+        public Unit<Resistance> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Resistance> DefaultUnitDefinition => Ohm;
 
         /// <inheritdoc/>
         public string QuantityFamily => "Electronic";

--- a/Elements.Quantity/Quantities/Electronic/Voltage.cs
+++ b/Elements.Quantity/Quantities/Electronic/Voltage.cs
@@ -84,7 +84,10 @@ namespace Elements.Quantity
         #region UNITS
 
         // provide a default unit for the quantity - used when no explicit unit specified
-        public Unit<Voltage> DefaultUnit { get { return Volt; } }
+        [Obsolete("Use 'Unit<Voltage>.DefaultUnitDefinition' instead.")]
+        public Unit<Voltage> DefaultUnit => DefaultUnitDefinition;
+
+        public static Unit<Voltage> DefaultUnitDefinition => Volt;
 
         /// <inheritdoc/>
         public string QuantityFamily => "Electronic";


### PR DESCRIPTION
> [!CAUTION]
> This PR needs to be rebased after #57 is merged in.

This PR replaces the instance-based `default(TQuantity).DefaultUnit` with a static default unit member enforced as a `static abstract` interface member in `IQuantity<T>`. All calls within the library that utilized the instance-based version have been replaced with the static-based one.

The new property is named `DefaultUnitDefinition` because the existing public instance property cannot share the same name. The instance property has been marked obsolete to avoid an immediate breaking change.

Unit tests have been added to test both versions to ensure the replacement performed exactly like the original.

Note that these unit tests utilize the newer version of the quantity tests found in PR #57. This PR must be merged into this repository first before this one. Once it is merged, this PR will be rebased.

Resolves #77  