### PR TITLE
Update AU and pc values to IAU approved values

### DIFF
--- a/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
+++ b/Elements.Quantity.Tests/Quantities/Basic/DistanceTests.cs
@@ -23,7 +23,7 @@ public class DistanceTests
     /// </remarks>
     internal static DistanceTestData[] DistanceTestDataTuples =>
     [
-        new (Distance.AU, "{0} AU", "1 Astronomical Unit", "{0} Astronomical Units", "Quantity.Unit.Distance.AstronomicalUnits"),
+        new (Distance.AU, "{0} au", "1 Astronomical Unit", "{0} Astronomical Units", "Quantity.Unit.Distance.AstronomicalUnits"),
         new (Distance.Angstrom, "{0} Å", "1 ångström", "{0} ångströms", "Quantity.Unit.Distance.Ångströms"),
         new (Distance.Foot, "{0} ft", "1 foot", "{0} feet", "Quantity.Unit.Distance.Feet"),
         new (Distance.Inch, "{0} in", "1 inch", "{0} inches", "Quantity.Unit.Distance.Inches"),

--- a/Elements.Quantity/Quantities/Basic/Distance.cs
+++ b/Elements.Quantity/Quantities/Basic/Distance.cs
@@ -83,7 +83,7 @@ namespace Elements.Quantity
         // IAU 2012 Resolution B2
         public static readonly Unit<Distance> AU = new Unit<Distance>(149597870700,
             new UnitGroup[] { UnitGroup.Astronomical, UnitGroup.Common },
-            new string[] { " AU" }, new string[] { " Astronomical Units", " Astronomical Unit", });
+            new string[] { " au", " AU" }, new string[] { " Astronomical Units", " Astronomical Unit", });
 
         public static readonly Unit<Distance> Lightyear = new Unit<Distance>(9.4607304725808e15,
             new UnitGroup[] { UnitGroup.Astronomical, UnitGroup.Common },

--- a/Elements.Quantity/Quantities/Basic/Distance.cs
+++ b/Elements.Quantity/Quantities/Basic/Distance.cs
@@ -80,7 +80,8 @@ namespace Elements.Quantity
             new UnitGroup[] { UnitGroup.Astronomical },
             new string[] { " R☉" }, new string[] { " Solar radii", " Solar radius" });
 
-        public static readonly Unit<Distance> AU = new Unit<Distance>(149597871464,
+        // IAU 2012 Resolution B2
+        public static readonly Unit<Distance> AU = new Unit<Distance>(149597870700,
             new UnitGroup[] { UnitGroup.Astronomical, UnitGroup.Common },
             new string[] { " AU" }, new string[] { " Astronomical Units", " Astronomical Unit", });
 
@@ -91,8 +92,8 @@ namespace Elements.Quantity
         public static readonly Unit<Distance> Lightsecond = new Unit<Distance>(299792458,
             new UnitGroup[] { UnitGroup.Astronomical },
             new string[] { " ls" }, new string[] { " lightseconds", " lightsecond" });
-
-        public static readonly Unit<Distance> Parsec = new Unit<Distance>(3.0857e16,
+        // IAU 2015 Resolution B2 (footnote 4)
+        public static readonly Unit<Distance> Parsec = new Unit<Distance>(3.085677581e16,
             new UnitGroup[] { UnitGroup.Astronomical },
             new string[] { " pc" }, new string[] { " parsecs", " parsec" });
 


### PR DESCRIPTION
Adjust AU and pc to use IAU exact values. Also change the preferred abbreviation for Astronomical Units to `au` in accordance with Res_AU2012_B2.

### Astronomical Unit

- https://iauarchive.eso.org/public/themes/measuring/
- https://syrte.obspm.fr/IAU_resolutions/Res_IAU2012_B2.pdf

### Parsec

- https://syrte.obspm.fr/IAU_resolutions/Res_IAU2012_B2.pdf (footnote 4)